### PR TITLE
Bump version to v0.1.8

### DIFF
--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer:
 pkgname=verify-everything
-pkgver=0.1.7
+pkgver=0.1.8
 pkgrel=1
 pkgdesc='LLM-based code review tool that finds issues tests and linters miss'
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "verify-everything"
-version = "0.1.7"
+version = "0.1.8"
 description = "LLM-based code review tool that finds issues tests and linters miss"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary
- Bump version from `0.1.7` to `0.1.8` in `pyproject.toml` and `pkg/arch/PKGBUILD`
- Tag `v0.1.8` has been pushed, which will trigger the `Publish / PyPI` workflow