### PR TITLE
Bump version to 0.1.11

### DIFF
--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer:
 pkgname=verify-everything
-pkgver=0.1.10
+pkgver=0.1.11
 pkgrel=1
 pkgdesc='LLM-based code review tool that finds issues tests and linters miss'
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "verify-everything"
-version = "0.1.10"
+version = "0.1.11"
 description = "LLM-based code review tool that finds issues tests and linters miss"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary

- Bumps version to `0.1.11` in `pyproject.toml` and `pkg/arch/PKGBUILD`
- Tag `v0.1.11` has been pushed to trigger the `Publish / PyPI` workflow

### Changes since v0.1.10

- Restyled PR review and CLI text output with emoji prefix, `Vet Issue` label, backtick-wrapped issue codes, and italic comma-separated metadata