### PR TITLE
updated the README.md file to give an example of openrouter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ jobs:
           agentic: false
 ```
 
-The action handles Python setup, vet installation, merge base computation, and posting the review to the PR. `OPENROUTER_API_KEY` must be set as a repository secret when using OpenRouter models. See [`action.yml`](https://github.com/imbue-ai/vet/blob/main/action.yml) for all available inputs.
+The action handles Python setup, vet installation, merge base computation, and posting the review to the PR. `ANTHROPIC_API_KEY` must be set as a repository secret when using Anthropic models (the default). See [`action.yml`](https://github.com/imbue-ai/vet/blob/main/action.yml) for all available inputs.
 
 ## How it works
 


### PR DESCRIPTION
This PR updates the models.json example to better reflect real usage.
Since OpenAI and Anthropic models are already defined in code, the example now focuses on OpenRouter models to avoid redundancy and provide clearer guidance for users configuring external providers.