### PR TITLE
Tell agent to consider updating if things break

### DIFF
--- a/skills/vet/SKILL.md
+++ b/skills/vet/SKILL.md
@@ -76,3 +76,9 @@ Vet analyzes the full git diff from the base commit. This may include changes fr
 - `--quiet`: Suppress status messages and 'No issues found.'
 - `--agentic`: Mode that routes analysis through the locally installed Claude Code or Codex CLI instead of calling the API directly. Try this if vet fails due to missing API keys. Slower (~3 min) so not recommended as the default.
 - `--help`: Show comprehensive list of options
+
+## Updating
+
+The vet CLI, skill files, and export scripts can become outdated as things change. The export scripts in particular are tightly coupled to the session storage formats of Codex, Claude Code, and OpenCode, which will change over time.
+
+If vet or the export scripts fail unexpectedly, try updating them. Run `which vet` to determine how vet was installed and update accordingly. For the skill files, check which skill directories exist on disk and update them with the latest versions from https://github.com/imbue-ai/vet/tree/main/skills/vet.


### PR DESCRIPTION
- This can happen because export scripts change over time as codex / cc / opencode change their interfaces, as happened just now. 