### PR TITLE
make list-models respect current run configuration

### DIFF
--- a/vet/imbue_tools/types/vet_config.py
+++ b/vet/imbue_tools/types/vet_config.py
@@ -30,8 +30,8 @@ class VetConfig(SerializableModel):
     custom_guides_config: CustomGuidesConfig | None = None
 
     # Todo: Different models for different issue identifiers
-    language_model_generation_config: LanguageModelGenerationConfig = (
-        LanguageModelGenerationConfig(model_name=AnthropicModelName.CLAUDE_4_6_OPUS)
+    language_model_generation_config: LanguageModelGenerationConfig = LanguageModelGenerationConfig(
+        model_name=AnthropicModelName.CLAUDE_4_6_OPUS
     )
     max_identifier_spend_dollars: float | None = None
     max_output_tokens: int = 20000
@@ -103,10 +103,6 @@ def get_enabled_issue_codes(config: VetConfig) -> set[IssueCode]:
     for code in explicitly_enabled + explicitly_disabled:
         if code not in all_issue_code_values:
             raise ValueError(f"Bad config: unknown issue code: {code}")
-    possibly_enabled_values = (
-        set(explicitly_enabled)
-        if len(explicitly_enabled) > 0
-        else set(v for v in IssueCode)
-    )
+    possibly_enabled_values = set(explicitly_enabled) if len(explicitly_enabled) > 0 else set(v for v in IssueCode)
     disabled_values = set(explicitly_disabled)
     return possibly_enabled_values - disabled_values

--- a/vet/issue_identifiers/agentic_issue_collation.py
+++ b/vet/issue_identifiers/agentic_issue_collation.py
@@ -11,9 +11,7 @@ from vet.imbue_core.data_types import IssueIdentificationLLMResponseMetadata
 from vet.imbue_core.data_types import LLMResponse
 from vet.imbue_tools.get_conversation_history.input_data_types import CommitInputs
 from vet.imbue_tools.get_conversation_history.input_data_types import IdentifierInputs
-from vet.imbue_tools.get_conversation_history.input_data_types import (
-    to_specific_inputs_type,
-)
+from vet.imbue_tools.get_conversation_history.input_data_types import to_specific_inputs_type
 from vet.imbue_tools.repo_utils.context_utils import escape_prompt_markers
 from vet.imbue_tools.repo_utils.project_context import ProjectContext
 from vet.imbue_tools.types.vet_config import VetConfig
@@ -79,8 +77,7 @@ def _get_collation_prompt(
     # Sort issue codes to make the resulting prompts deterministic (for snapshot tests and LLM caching)
     sorted_issue_codes = sorted(enabled_issue_codes)
     formatted_guides = {
-        code: format_issue_identification_guide_for_llm(guides_by_issue_code[code])
-        for code in sorted_issue_codes
+        code: format_issue_identification_guide_for_llm(guides_by_issue_code[code]) for code in sorted_issue_codes
     }
 
     env = jinja2.Environment(undefined=jinja2.StrictUndefined)
@@ -116,9 +113,7 @@ def _convert_parsed_issues_to_combined_string(
 
 
 def collate_issues_with_agent(
-    issue_generator: Generator[
-        GeneratedIssueSchema, None, IssueIdentificationDebugInfo
-    ],
+    issue_generator: Generator[GeneratedIssueSchema, None, IssueIdentificationDebugInfo],
     identifier_inputs: IdentifierInputs,
     project_context: ProjectContext,
     config: VetConfig,
@@ -166,12 +161,8 @@ def collate_issues_with_agent(
     claude_response = generate_response_from_agent(collation_prompt, options)
     assert claude_response is not None
     response_text, collation_messages = claude_response
-    collation_raw_messages = tuple(
-        json.dumps(message.model_dump()) for message in collation_messages
-    )
-    collation_invocation_info = extract_invocation_info_from_messages(
-        collation_messages
-    )
+    collation_raw_messages = tuple(json.dumps(message.model_dump()) for message in collation_messages)
+    collation_invocation_info = extract_invocation_info_from_messages(collation_messages)
 
     collation_llm_responses = (
         LLMResponse(

--- a/vet/issue_identifiers/common.py
+++ b/vet/issue_identifiers/common.py
@@ -35,12 +35,8 @@ from vet.imbue_core.data_types import IssueLocation
 from vet.imbue_core.data_types import LineRange
 from vet.imbue_core.data_types import SeverityScore
 from vet.imbue_core.pydantic_serialization import SerializableModel
-from vet.imbue_tools.llm_output_parsing.parse_model_json_response import (
-    ResponseParsingError,
-)
-from vet.imbue_tools.llm_output_parsing.parse_model_json_response import (
-    parse_model_json_response,
-)
+from vet.imbue_tools.llm_output_parsing.parse_model_json_response import ResponseParsingError
+from vet.imbue_tools.llm_output_parsing.parse_model_json_response import parse_model_json_response
 from vet.imbue_tools.repo_utils.project_context import ProjectContext
 from vet.issue_identifiers.identification_guides import IssueIdentificationGuide
 from vet.issue_identifiers.utils import ReturnCapturingGenerator
@@ -50,22 +46,12 @@ class GeneratedIssueSchema(SerializableModel):
     """Individual issue from LLM response."""
 
     issue_code: str = Field(description="Category of the issue")
-    description: str = Field(
-        description="Specific explanation of what's wrong and why it's incorrect"
-    )
-    location: str | None = Field(
-        default=None, description="File path where the issue occurs"
-    )
-    code_part: str | None = Field(
-        default=None, description="Specific code snippet that has the issue"
-    )
+    description: str = Field(description="Specific explanation of what's wrong and why it's incorrect")
+    location: str | None = Field(default=None, description="File path where the issue occurs")
+    code_part: str | None = Field(default=None, description="Specific code snippet that has the issue")
     # pyre doesn't like the way ints/floats implement ge/le
-    severity: int = Field(
-        description="Integer 1-5 (1=minor issue, 5=critical bug)", ge=1, le=5
-    )  # pyre-ignore[6]
-    confidence: float = Field(
-        description="Confidence in this assessment", ge=0.0, le=1.0
-    )  # pyre-ignore[6]
+    severity: int = Field(description="Integer 1-5 (1=minor issue, 5=critical bug)", ge=1, le=5)  # pyre-ignore[6]
+    confidence: float = Field(description="Confidence in this assessment", ge=0.0, le=1.0)  # pyre-ignore[6]
 
     # ----------------------------------------------------------------
     # Internal mutable fields used by the post-identification pipeline for tagging.
@@ -91,9 +77,7 @@ class GeneratedIssueSchema(SerializableModel):
 class GeneratedResponseSchema(SerializableModel):
     """Complete response structure for issue identification."""
 
-    issues: list[GeneratedIssueSchema] = Field(
-        default_factory=list, description="List of identified issues"
-    )
+    issues: list[GeneratedIssueSchema] = Field(default_factory=list, description="List of identified issues")
 
 
 def generate_issues_from_response_texts(
@@ -102,9 +86,7 @@ def generate_issues_from_response_texts(
     """Generate IssueIdentifierResult objects from LLM response text."""
     for response_text in response_texts:
         try:
-            parsed_data = parse_model_json_response(
-                response_text, GeneratedResponseSchema
-            )
+            parsed_data = parse_model_json_response(response_text, GeneratedResponseSchema)
         except ResponseParsingError:
             logger.warning(f"Failed to parse response text: {response_text}")
             continue
@@ -113,9 +95,7 @@ def generate_issues_from_response_texts(
             yield raw_issue
 
 
-def line_ranges_to_issue_locations(
-    line_ranges: Iterable[LineRange], file_path: str
-) -> tuple[IssueLocation, ...]:
+def line_ranges_to_issue_locations(line_ranges: Iterable[LineRange], file_path: str) -> tuple[IssueLocation, ...]:
     """Convert LineRange objects to IssueLocation objects."""
     return tuple(
         IssueLocation(
@@ -148,11 +128,7 @@ def convert_generated_issue_to_identified_issue(
         issue_location = issue_data.location
         try:
             issue_location_path = Path(issue_location) if issue_location else None
-            if (
-                project_context.repo_path
-                and issue_location_path
-                and issue_location_path.is_absolute()
-            ):
+            if project_context.repo_path and issue_location_path and issue_location_path.is_absolute():
                 # Make absolute path relative.
                 # This will raise ValueError if issue_location_path is not under repo_path.
                 repo_path = project_context.repo_path
@@ -160,14 +136,10 @@ def convert_generated_issue_to_identified_issue(
                 issue_location_path = issue_location_path.relative_to(repo_path)
         except ValueError:
             issue_location_path = None
-            logger.warning(
-                f"Invalid location '{issue_location}', skipping line range detection."
-            )
+            logger.warning(f"Invalid location '{issue_location}', skipping line range detection.")
         issue_code_part = issue_data.code_part
         if issue_location_path and issue_code_part:
-            contents = project_context.file_contents_by_path.get(
-                issue_location_path.as_posix()
-            )
+            contents = project_context.file_contents_by_path.get(issue_location_path.as_posix())
             if contents is not None:
                 line_ranges = LineRange.build_from_substring(contents, issue_code_part)
                 if not line_ranges:
@@ -177,9 +149,7 @@ def convert_generated_issue_to_identified_issue(
                         code_part_repr=repr(issue_code_part),
                     )
             else:
-                logger.warning(
-                    f"Unknown location '{issue_location}', skipping line range detection."
-                )
+                logger.warning(f"Unknown location '{issue_location}', skipping line range detection.")
 
         # Convert severity (1-5) to normalized score (0-1)
         severity_normalized = (issue_data.severity - 1) / 4.0  # Map 1-5 to 0-1
@@ -189,12 +159,8 @@ def convert_generated_issue_to_identified_issue(
         return IdentifiedVerifyIssue(
             code=IssueCode(issue_data.issue_code),
             description=issue_data.description,
-            severity_score=SeverityScore(
-                raw=issue_data.severity, normalized=severity_normalized
-            ),
-            confidence_score=ConfidenceScore(
-                raw=issue_data.confidence, normalized=issue_data.confidence
-            ),
+            severity_score=SeverityScore(raw=issue_data.severity, normalized=severity_normalized),
+            confidence_score=ConfidenceScore(raw=issue_data.confidence, normalized=issue_data.confidence),
             location=locations,
         )
 
@@ -221,16 +187,12 @@ def convert_to_issue_identifier_result(
             enabled_issue_codes=enabled_issue_codes,
         )
         if issue:
-            yield IssueIdentifierResult(
-                issue=issue, passes_filtration=issue_data.passes_filtration
-            )
+            yield IssueIdentifierResult(issue=issue, passes_filtration=issue_data.passes_filtration)
 
     return generator_with_capture.return_value
 
 
-def get_agent_options(
-    cwd: Path | None, model_name: str | None, agent_harness_type: AgentHarnessType
-) -> AgentOptions:
+def get_agent_options(cwd: Path | None, model_name: str | None, agent_harness_type: AgentHarnessType) -> AgentOptions:
     """Build agent options for the given harness type.
 
     *model_name* is passed through to the underlying CLI as-is.  When ``None``,
@@ -254,9 +216,7 @@ def get_agent_options(
     )
 
 
-def generate_response_from_agent(
-    prompt: str, options: AgentOptions
-) -> tuple[str, list[AgentMessage]] | None:
+def generate_response_from_agent(prompt: str, options: AgentOptions) -> tuple[str, list[AgentMessage]] | None:
     messages = []
     assistant_messages = []
     result_message = None
@@ -302,8 +262,7 @@ def extract_invocation_info_from_costed_response(
         if caching_info.provider_specific_data is not None:
             if isinstance(caching_info.provider_specific_data, AnthropicCachingInfo):
                 cache_creation_tokens = (
-                    caching_info.provider_specific_data.written_5m
-                    + caching_info.provider_specific_data.written_1h
+                    caching_info.provider_specific_data.written_5m + caching_info.provider_specific_data.written_1h
                 )
             else:
                 logger.debug(

--- a/vet/issue_identifiers/harnesses/agentic.py
+++ b/vet/issue_identifiers/harnesses/agentic.py
@@ -177,12 +177,8 @@ def _generate_issues_worker(
 class _AgenticIssueIdentifier(IssueIdentifier[CommitInputs]):
     _identification_guides: tuple[IssueIdentificationGuide, ...]
 
-    def __init__(
-        self, identification_guides: tuple[IssueIdentificationGuide, ...]
-    ) -> None:
-        assert len(identification_guides) > 0, (
-            "At least one identification guide must be provided"
-        )
+    def __init__(self, identification_guides: tuple[IssueIdentificationGuide, ...]) -> None:
+        assert len(identification_guides) > 0, "At least one identification guide must be provided"
         self._identification_guides = identification_guides
 
     @cached_property
@@ -198,13 +194,11 @@ class _AgenticIssueIdentifier(IssueIdentifier[CommitInputs]):
         env = jinja2.Environment(undefined=jinja2.StrictUndefined)
         jinja_template = env.from_string(PROMPT_TEMPLATE)
         additional_guidance_by_issue_code = {
-            guide.issue_code: guide.additional_guide_for_agent
-            for guide in self._identification_guides
+            guide.issue_code: guide.additional_guide_for_agent for guide in self._identification_guides
         }
 
         formatted_guides = {
-            guide.issue_code: format_issue_identification_guide_for_llm(guide)
-            for guide in self._identification_guides
+            guide.issue_code: format_issue_identification_guide_for_llm(guide) for guide in self._identification_guides
         }
 
         prompt = jinja_template.render(
@@ -248,9 +242,7 @@ class _AgenticIssueIdentifier(IssueIdentifier[CommitInputs]):
         project_context: ProjectContext,
         config: VetConfig,
     ) -> Generator[GeneratedIssueSchema, None, IssueIdentificationDebugInfo]:
-        assert project_context.repo_path is not None, (
-            "Project context must have a valid repo_path, got None"
-        )
+        assert project_context.repo_path is not None, "Project context must have a valid repo_path, got None"
 
         options = get_agent_options(
             cwd=project_context.repo_path,
@@ -264,19 +256,13 @@ class _AgenticIssueIdentifier(IssueIdentifier[CommitInputs]):
             issue_prompts = [
                 (
                     guide.issue_code,
-                    self._get_prompt_for_issue_type(
-                        project_context, identifier_inputs, guide
-                    ),
+                    self._get_prompt_for_issue_type(project_context, identifier_inputs, guide),
                 )
                 for guide in self._identification_guides
             ]
-            with ThreadPoolExecutor(
-                max_workers=config.max_identify_workers
-            ) as executor:
+            with ThreadPoolExecutor(max_workers=config.max_identify_workers) as executor:
                 tasks = [
-                    executor.submit(
-                        _generate_issues_worker, issue_code, prompt, options
-                    )
+                    executor.submit(_generate_issues_worker, issue_code, prompt, options)
                     for issue_code, prompt in issue_prompts
                 ]
 
@@ -292,13 +278,9 @@ class _AgenticIssueIdentifier(IssueIdentifier[CommitInputs]):
 
                     issue_code, issue_type_response_text, messages = result
 
-                    yield from generate_issues_from_response_texts(
-                        response_texts=(issue_type_response_text,)
-                    )
+                    yield from generate_issues_from_response_texts(response_texts=(issue_type_response_text,))
 
-                    message_dumps = tuple(
-                        json.dumps(message.model_dump()) for message in messages
-                    )
+                    message_dumps = tuple(json.dumps(message.model_dump()) for message in messages)
                     invocation_info = extract_invocation_info_from_messages(messages)
 
                     llm_responses.append(
@@ -319,9 +301,7 @@ class _AgenticIssueIdentifier(IssueIdentifier[CommitInputs]):
             assert claude_response is not None
             response_text, messages = claude_response
 
-            message_dumps = tuple(
-                json.dumps(message.model_dump()) for message in messages
-            )
+            message_dumps = tuple(json.dumps(message.model_dump()) for message in messages)
             invocation_info = extract_invocation_info_from_messages(messages)
 
             llm_responses = [
@@ -335,9 +315,7 @@ class _AgenticIssueIdentifier(IssueIdentifier[CommitInputs]):
                 )
             ]
 
-            yield from generate_issues_from_response_texts(
-                response_texts=(response_text,)
-            )
+            yield from generate_issues_from_response_texts(response_texts=(response_text,))
 
             return IssueIdentificationDebugInfo(llm_responses=tuple(llm_responses))
 


### PR DESCRIPTION
- list-models should only show models that are supported using the current configuration
  - vet --list-models should show registered models that support endpoint llm calls
  - vet --list-models --agentic should only show models for the default agent harness
  - vet --list-models --agentic --agent-harness codex should only show codex supported models 
- ignore cast from repo because I like recording asciinema