### PR TITLE
Bump version to v0.2.2

### DIFF
--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer:
 pkgname=verify-everything
-pkgver=0.2.1
+pkgver=0.2.2
 pkgrel=1
 pkgdesc='LLM-based code review tool that finds issues tests and linters miss'
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "verify-everything"
-version = "0.2.1"
+version = "0.2.2"
 description = "LLM-based code review tool that finds issues tests and linters miss"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary

- Bump version to v0.2.2 in `pyproject.toml` and `pkg/arch/PKGBUILD`

### Changes since v0.2.1

- Better error handling and messaging for missing Codex/Claude Code (#154, #159, #160)
- Support for longer diffs with Codex (#157)
- DevEx improvements: replaced Dockerfile with Containerfile, run vet from containers (#161, #163)
- Updated skill messaging and `--agentic` flag docs (#153, #162)