### PR TITLE
Inform users about subscription support via --agentic

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@
 
 - **Reviews intent and code**: checks agent conversations for goal adherence and code changes for correctness.
 - **Runs anywhere**: from the terminal, as an agent skill, or in CI.
-- **Bring-your-own-model**: works with any provider using your own API keys, no subscription ever.
-- **No data collection**: requests go directly to inference providers, never through our servers.
+- **Bring-your-own-model**: works with any provider using your own API keys.
+- **Works with existing subscriptions**: supports Anthropic and OpenAI subscriptions using [`--agentic`](#usage).
+- **Free and open source**: no account, fees, or data collection. Requests go directly to your inference provider. Licensed under the AGPL-3.0.
 
 <p align="center">
   <a href="https://github.com/imbue-ai/vet">
@@ -110,6 +111,12 @@ Compare against a base ref/commit:
 
 ```bash
 vet "Refactor storage layer" --base-commit main
+```
+
+Use Claude Code or Codex instead of LLM APIs (`--agent-harness`: `claude`, `codex`):
+
+```bash
+vet "Implement X without breaking Y" --agentic --agent-harness claude
 ```
 
 ## GitHub PRs (Actions)

--- a/vet/cli/main.py
+++ b/vet/cli/main.py
@@ -660,6 +660,11 @@ def main(argv: list[str] | None = None) -> int:
             validate_api_key_for_model(model_id, user_config, registry_config)
         except Exception as e:
             print(f"vet: {e}", file=sys.stderr)
+            print(
+                "hint: If you have a Claude or Codex subscription, try --agentic to use your\n"
+                "      locally installed coding agent CLI instead.",
+                file=sys.stderr,
+            )
             return 2
 
         # TODO: Support OFFLINE, UPDATE_SNAPSHOT, and MOCKED modes.
@@ -721,6 +726,11 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     except MissingAPIKeyError as e:
         print(f"vet: {e}", file=sys.stderr)
+        print(
+            "hint: If you have a Claude or Codex subscription, try --agentic to use your\n"
+            "      locally installed coding agent CLI instead.",
+            file=sys.stderr,
+        )
         return 2
     # TODO: This should be refactored so we only need to handle prompt too long errors when context is overfilled.
     except (PromptTooLongError, BadAPIRequestError) as e:


### PR DESCRIPTION
## Summary

- Add a hint to API key error messages suggesting `--agentic` for users with Claude or Codex subscriptions
- Update `--agentic` help text to clarify it uses Claude Code or Codex CLI
- Update README and SKILL.md to mention subscription support

When a user hits a missing API key error, they now see:

```
vet: Neither ANTHROPIC_API_KEY nor ANTHROPIC_AUTH_TOKEN environment variable is set
hint: If you have a Claude or Codex subscription, try --agentic to use your
      locally installed coding agent CLI instead.
```