### PR TITLE
fix: don't pass cwd to transport in opencode harness

### DIFF
--- a/vet/imbue_core/agents/agent_api/opencode/client.py
+++ b/vet/imbue_core/agents/agent_api/opencode/client.py
@@ -34,9 +34,7 @@ class OpenCodeClient(RealAgentClient[OpenCodeOptions]):
         )
 
         cmd = self._build_cli_cmd(self._options)
-        with AgentSubprocessCLITransport.build(
-            AgentSubprocessCLITransportOptions(cmd=cmd, cwd=self._options.cwd)
-        ) as transport:
+        with AgentSubprocessCLITransport.build(AgentSubprocessCLITransportOptions(cmd=cmd)) as transport:
             transport.write_stdin(prompt)
 
             for data in transport.receive_messages():

--- a/vet/imbue_core/agents/agent_api/opencode/client_test.py
+++ b/vet/imbue_core/agents/agent_api/opencode/client_test.py
@@ -161,6 +161,52 @@ class TestProcessQuery:
         assert messages[0].error == "Rate limit exceeded"
 
 
+class TestTransportOptions:
+    def test_transport_not_passed_cwd(self) -> None:
+        text_event = {
+            "type": "text",
+            "timestamp": 1,
+            "sessionID": "ses_test",
+            "part": {
+                "id": "prt_1",
+                "sessionID": "ses_test",
+                "messageID": "msg_1",
+                "type": "text",
+                "text": "hi",
+            },
+        }
+        result_event = {
+            "type": "step_finish",
+            "timestamp": 2,
+            "sessionID": "ses_test",
+            "part": {
+                "id": "prt_2",
+                "sessionID": "ses_test",
+                "messageID": "msg_1",
+                "type": "step-finish",
+                "reason": "stop",
+            },
+        }
+
+        mock_transport = MagicMock()
+        mock_transport.receive_messages.return_value = iter([text_event, result_event])
+        mock_transport.write_stdin = MagicMock()
+        mock_transport.__enter__ = MagicMock(return_value=mock_transport)
+        mock_transport.__exit__ = MagicMock(return_value=False)
+
+        options = OpenCodeOptions(cli_path=Path("/usr/bin/opencode"), cwd="/my/project")
+
+        with patch(
+            "vet.imbue_core.agents.agent_api.opencode.client.AgentSubprocessCLITransport.build",
+            return_value=mock_transport,
+        ) as mock_build:
+            client = OpenCodeClient(options)
+            list(client.process_query("test"))
+
+        transport_options = mock_build.call_args[0][0]
+        assert transport_options.cwd is None
+
+
 class TestBuildContextManager:
     def test_build_yields_client(self) -> None:
         options = OpenCodeOptions(cli_path=Path("/usr/bin/opencode"))


### PR DESCRIPTION
## Summary
- Fix BrokenPipeError when using `--agentic --agent-harness opencode` by removing duplicate cwd handling
- The opencode client was passing `cwd` to both the subprocess Popen (via transport options) AND as `--dir` to the opencode CLI, causing opencode to resolve `--dir <path>` relative to the already-changed working directory (e.g. `bouncer/bouncer/`)
- Add regression test verifying the transport is built without cwd

## Root Cause
When `vet --agentic --agent-harness opencode --repo bouncer` runs, the `OpenCodeClient.process_query()` method:
1. Builds the command: `opencode run --format json --dir bouncer`
2. Creates the transport with `AgentSubprocessCLITransportOptions(cmd=cmd, cwd="bouncer")`

The transport's `Popen(cmd, cwd="bouncer")` starts the opencode process with working directory set to `bouncer/`. Then opencode receives `--dir bouncer` and tries to change to `bouncer/bouncer/`, which doesn't exist. OpenCode exits with "Failed to change directory to bouncer", and vet gets a `BrokenPipeError` when trying to write the prompt to the dead process's stdin.

## Fix
Remove `cwd` from the transport options since `--dir` already tells opencode where to work. This matches how the Claude harness works (it doesn't pass cwd to the transport either).