### PR TITLE
chore: bump version to v0.2.9

### DIFF
--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer:
 pkgname=verify-everything
-pkgver=0.2.8
+pkgver=0.2.9
 pkgrel=1
 pkgdesc='LLM-based code review tool that finds issues tests and linters miss'
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "verify-everything"
-version = "0.2.8"
+version = "0.2.9"
 description = "LLM-based code review tool that finds issues tests and linters miss"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary
- Bump version to v0.2.9 in `pyproject.toml` and `pkg/arch/PKGBUILD`
- Tag `v0.2.9` pushed to trigger PyPI publish

### Changes in v0.2.9
- Fix opencode harness `BrokenPipeError` caused by passing `cwd` to both the subprocess and `--dir` flag (#192)