### PR TITLE
Add Claude Opus 4.7 support, make it the default

### DIFF
--- a/.vet/models.json
+++ b/.vet/models.json
@@ -50,13 +50,13 @@
           "max_output_tokens": 64000,
           "supports_temperature": true
         },
-        "opus": {
+        "opus-4.6": {
           "model_id": "claude-opus-4-6",
           "context_window": 200000,
           "max_output_tokens": 128000,
           "supports_temperature": true
         },
-        "opus-4.7": {
+        "opus": {
           "model_id": "claude-opus-4-7",
           "context_window": 200000,
           "max_output_tokens": 128000,

--- a/.vet/models.json
+++ b/.vet/models.json
@@ -50,13 +50,13 @@
           "max_output_tokens": 16384,
           "supports_temperature": true
         },
-        "opus": {
+        "opus-4.6": {
           "model_id": "claude-opus-4-6",
           "context_window": 200000,
           "max_output_tokens": 16384,
           "supports_temperature": true
         },
-        "opus-4.7": {
+        "opus": {
           "model_id": "claude-opus-4-7",
           "context_window": 200000,
           "max_output_tokens": 16384,

--- a/.vet/models.json
+++ b/.vet/models.json
@@ -51,7 +51,7 @@
           "supports_temperature": true
         },
         "opus": {
-          "model_id": "claude-opus-4-6",
+          "model_id": "claude-opus-4-7",
           "context_window": 200000,
           "max_output_tokens": 16384,
           "supports_temperature": true

--- a/.vet/models.json
+++ b/.vet/models.json
@@ -51,6 +51,12 @@
           "supports_temperature": true
         },
         "opus": {
+          "model_id": "claude-opus-4-6",
+          "context_window": 200000,
+          "max_output_tokens": 16384,
+          "supports_temperature": true
+        },
+        "opus-4.7": {
           "model_id": "claude-opus-4-7",
           "context_window": 200000,
           "max_output_tokens": 16384,

--- a/.vet/models.json
+++ b/.vet/models.json
@@ -41,26 +41,26 @@
         "sonnet": {
           "model_id": "claude-sonnet-4-6",
           "context_window": 200000,
-          "max_output_tokens": 16384,
+          "max_output_tokens": 64000,
           "supports_temperature": true
         },
         "haiku": {
           "model_id": "claude-haiku-4-5",
           "context_window": 200000,
-          "max_output_tokens": 16384,
-          "supports_temperature": true
-        },
-        "opus-4.6": {
-          "model_id": "claude-opus-4-6",
-          "context_window": 200000,
-          "max_output_tokens": 16384,
+          "max_output_tokens": 64000,
           "supports_temperature": true
         },
         "opus": {
+          "model_id": "claude-opus-4-6",
+          "context_window": 200000,
+          "max_output_tokens": 128000,
+          "supports_temperature": true
+        },
+        "opus-4.7": {
           "model_id": "claude-opus-4-7",
           "context_window": 200000,
-          "max_output_tokens": 16384,
-          "supports_temperature": true
+          "max_output_tokens": 128000,
+          "supports_temperature": false
         }
       }
     },

--- a/skills/vet/SKILL.md
+++ b/skills/vet/SKILL.md
@@ -99,7 +99,7 @@ Vet analyzes the full git diff from the base commit. This may include changes fr
 ## Common Options
 
 - `--base-commit REF`: Git ref for diff base (default: HEAD)
-- `--model MODEL`: LLM to use (default: claude-opus-4-6)
+- `--model MODEL`: LLM to use (default: claude-opus-4-7)
 - `--list-models`: list all models that are supported by vet
     - Run `vet --help` and look at the vet repo's readme for details about defining custom OpenAI-compatible models.
 - `--update-models`: fetch the latest community model definitions from the remote registry and cache them locally. See "Updating the Model Registry" below for when to run this.

--- a/uv.lock
+++ b/uv.lock
@@ -1494,7 +1494,7 @@ wheels = [
 
 [[package]]
 name = "verify-everything"
-version = "0.2.7"
+version = "0.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/vet/cli/main.py
+++ b/vet/cli/main.py
@@ -152,7 +152,7 @@ def create_parser() -> argparse.ArgumentParser:
         default=CLI_DEFAULTS.model,
         metavar="MODEL",
         # Hardcoded to avoid importing cli.models at module level (~1s of SDK imports).
-        help="LLM to use for analysis (default: claude-opus-4-6).",
+        help="LLM to use for analysis (default: claude-opus-4-7).",
     )
     model_group.add_argument(
         "--list-models",

--- a/vet/cli/models.py
+++ b/vet/cli/models.py
@@ -59,9 +59,7 @@ def validate_model_id(
     registry_config: ModelsConfig | None = None,
 ) -> str:
     if not is_valid_model_id(model_id, user_config, registry_config):
-        raise ValueError(
-            f"Unknown model: {model_id}. Use --list-models to see available models."
-        )
+        raise ValueError(f"Unknown model: {model_id}. Use --list-models to see available models.")
     return model_id
 
 

--- a/vet/cli/models.py
+++ b/vet/cli/models.py
@@ -12,7 +12,7 @@ from vet.imbue_core.agents.llm_apis.common import get_all_model_names
 from vet.imbue_core.agents.llm_apis.gemini_api import GeminiModelName
 from vet.imbue_core.agents.llm_apis.openai_api import OpenAIModelName
 
-DEFAULT_MODEL_ID = AnthropicModelName.CLAUDE_4_6_OPUS.value
+DEFAULT_MODEL_ID = AnthropicModelName.CLAUDE_4_7_OPUS.value
 
 
 class MissingProviderAPIKeyError(Exception):
@@ -59,7 +59,9 @@ def validate_model_id(
     registry_config: ModelsConfig | None = None,
 ) -> str:
     if not is_valid_model_id(model_id, user_config, registry_config):
-        raise ValueError(f"Unknown model: {model_id}. Use --list-models to see available models.")
+        raise ValueError(
+            f"Unknown model: {model_id}. Use --list-models to see available models."
+        )
     return model_id
 
 

--- a/vet/imbue_core/agents/llm_apis/anthropic_api.py
+++ b/vet/imbue_core/agents/llm_apis/anthropic_api.py
@@ -59,6 +59,7 @@ class AnthropicModelName(enum.StrEnum):
     CLAUDE_4_1_OPUS = "claude-opus-4-1"
     CLAUDE_4_5_OPUS = "claude-opus-4-5"
     CLAUDE_4_6_OPUS = "claude-opus-4-6"
+    CLAUDE_4_7_OPUS = "claude-opus-4-7"
     CLAUDE_4_SONNET = "claude-sonnet-4-0"
     CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
     CLAUDE_4_6_SONNET = "claude-sonnet-4-6"
@@ -69,6 +70,7 @@ class AnthropicModelName(enum.StrEnum):
     CLAUDE_4_SONNET_LONG = "claude-sonnet-4-0-long"
     CLAUDE_4_5_SONNET_LONG = "claude-sonnet-4-5-long"
     CLAUDE_4_6_OPUS_LONG = "claude-opus-4-6-long"
+    CLAUDE_4_7_OPUS_LONG = "claude-opus-4-7-long"
 
 
 # Basic info is available at https://docs.anthropic.com/claude/reference/models
@@ -125,6 +127,21 @@ ANTHROPIC_MODEL_INFO_BY_NAME: FrozenMapping[AnthropicModelName, ModelInfo] = Fro
         ),
         AnthropicModelName.CLAUDE_4_6_OPUS: ModelInfo(
             model_name=AnthropicModelName.CLAUDE_4_6_OPUS,
+            cost_per_input_token=5.00 / 1_000_000,
+            cost_per_output_token=25.00 / 1_000_000,
+            max_input_tokens=200_000,
+            max_output_tokens=128_000,
+            rate_limit_req=4000 / 60,
+            rate_limit_tok=2_000_000 / 60,
+            rate_limit_output_tok=400_000 / 60,
+            provider_specific_info=AnthropicModelInfo(
+                cost_per_5m_cache_write_token=6.25 / 1_000_000,
+                cost_per_1h_cache_write_token=10 / 1_000_000,
+                cost_per_cache_read_token=0.50 / 1_000_000,
+            ),
+        ),
+        AnthropicModelName.CLAUDE_4_7_OPUS: ModelInfo(
+            model_name=AnthropicModelName.CLAUDE_4_7_OPUS,
             cost_per_input_token=5.00 / 1_000_000,
             cost_per_output_token=25.00 / 1_000_000,
             max_input_tokens=200_000,
@@ -229,6 +246,17 @@ ANTHROPIC_MODEL_INFO_BY_NAME: FrozenMapping[AnthropicModelName, ModelInfo] = Fro
             # the first 200_000 input tokens use the rate 5.0 / 1_000_000, and the next up to 800_000 use the rate 10.0 / 1_000_000.
             # thus the maximum average cost per input token is (5.0 * 200_000 + 10.0 * 800_000) / 1_000_000 = 9.0 per 1_000_000.
             # (all output tokens may be past 200_000 input tokens, so the max average cost there is just the cost for tokens after 200_000)
+            cost_per_input_token=9.00 / 1_000_000,
+            cost_per_output_token=37.50 / 1_000_000,
+            max_input_tokens=1_000_000,
+            max_output_tokens=128_000,
+            rate_limit_req=None,  # Currently no limit set in our dashboard
+            rate_limit_tok=1_000_000 / 60,
+            rate_limit_output_tok=200_000 / 60,
+        ),
+        AnthropicModelName.CLAUDE_4_7_OPUS_LONG: ModelInfo(
+            model_name=AnthropicModelName.CLAUDE_4_7_OPUS_LONG,
+            # Opus 4.7 has a native 1M context window. Pricing tiers match 4.6 long-context.
             cost_per_input_token=9.00 / 1_000_000,
             cost_per_output_token=37.50 / 1_000_000,
             max_input_tokens=1_000_000,
@@ -462,21 +490,17 @@ class AnthropicAPI(LanguageModelAPI):
                     params = chill(param_with_max_tokens_evolver)
                 assert params.max_tokens is not None, "max_tokens must be provided for Anthropic API"
 
-                if self.model_name in (
-                    AnthropicModelName.CLAUDE_4_5_SONNET_LONG,
-                    AnthropicModelName.CLAUDE_4_SONNET_LONG,
-                    AnthropicModelName.CLAUDE_4_6_OPUS_LONG,
-                ):
+                _LONG_TO_STANDARD = {
+                    AnthropicModelName.CLAUDE_4_5_SONNET_LONG: AnthropicModelName.CLAUDE_4_5_SONNET,
+                    AnthropicModelName.CLAUDE_4_SONNET_LONG: AnthropicModelName.CLAUDE_4_SONNET,
+                    AnthropicModelName.CLAUDE_4_6_OPUS_LONG: AnthropicModelName.CLAUDE_4_6_OPUS,
+                    AnthropicModelName.CLAUDE_4_7_OPUS_LONG: AnthropicModelName.CLAUDE_4_7_OPUS,
+                }
+
+                if self.model_name in _LONG_TO_STANDARD:
                     # FIXME: Fix this once this is no longer beta or as this becomes required for more models
                     # Map the name back to the actual model name for the API call
-                    if self.model_name == AnthropicModelName.CLAUDE_4_5_SONNET_LONG:
-                        model_name = AnthropicModelName.CLAUDE_4_5_SONNET
-                    elif self.model_name == AnthropicModelName.CLAUDE_4_SONNET_LONG:
-                        model_name = AnthropicModelName.CLAUDE_4_SONNET
-                    elif self.model_name == AnthropicModelName.CLAUDE_4_6_OPUS_LONG:
-                        model_name = AnthropicModelName.CLAUDE_4_6_OPUS
-                    else:
-                        assert False, "unreachable"
+                    model_name = _LONG_TO_STANDARD[self.model_name]
                     api_result = await client.beta.messages.create(
                         messages=non_system_messages,
                         stop_sequences=([params.stop] if params.stop is not None else NOT_GIVEN),
@@ -547,21 +571,17 @@ class AnthropicAPI(LanguageModelAPI):
                 max_tokens = params.max_tokens if params.max_tokens is not None else self.model_info.max_output_tokens
                 assert max_tokens is not None, "max_tokens must be provided for Anthropic API"
 
-                if self.model_name in (
-                    AnthropicModelName.CLAUDE_4_5_SONNET_LONG,
-                    AnthropicModelName.CLAUDE_4_SONNET_LONG,
-                    AnthropicModelName.CLAUDE_4_6_OPUS_LONG,
-                ):
+                _LONG_TO_STANDARD_STREAM = {
+                    AnthropicModelName.CLAUDE_4_5_SONNET_LONG: AnthropicModelName.CLAUDE_4_5_SONNET,
+                    AnthropicModelName.CLAUDE_4_SONNET_LONG: AnthropicModelName.CLAUDE_4_SONNET,
+                    AnthropicModelName.CLAUDE_4_6_OPUS_LONG: AnthropicModelName.CLAUDE_4_6_OPUS,
+                    AnthropicModelName.CLAUDE_4_7_OPUS_LONG: AnthropicModelName.CLAUDE_4_7_OPUS,
+                }
+
+                if self.model_name in _LONG_TO_STANDARD_STREAM:
                     # FIXME: Fix this once this is no longer beta or as this becomes required for more models
                     # Map the name back to the actual model name for the API call
-                    if self.model_name == AnthropicModelName.CLAUDE_4_5_SONNET_LONG:
-                        model_name = AnthropicModelName.CLAUDE_4_5_SONNET
-                    elif self.model_name == AnthropicModelName.CLAUDE_4_SONNET_LONG:
-                        model_name = AnthropicModelName.CLAUDE_4_SONNET
-                    elif self.model_name == AnthropicModelName.CLAUDE_4_6_OPUS_LONG:
-                        model_name = AnthropicModelName.CLAUDE_4_6_OPUS
-                    else:
-                        assert False, "unreachable"
+                    model_name = _LONG_TO_STANDARD_STREAM[self.model_name]
                     stream_fn = lambda **kwargs: client.beta.messages.stream(**kwargs, betas=["context-1m-2025-08-07"])
                     cache_info_maker = lambda api_result: AnthropicCachingInfo(
                         written_5m=api_result.usage.cache_creation.ephemeral_5m_input_tokens,

--- a/vet/imbue_core/agents/llm_apis/anthropic_api.py
+++ b/vet/imbue_core/agents/llm_apis/anthropic_api.py
@@ -269,6 +269,15 @@ ANTHROPIC_MODEL_INFO_BY_NAME: FrozenMapping[AnthropicModelName, ModelInfo] = Fro
 )
 
 
+# Opus 4.7+ does not support temperature, top_p, or top_k parameters.
+# Passing any non-default value returns a 400 error.
+_MODELS_WITHOUT_TEMPERATURE: frozenset[AnthropicModelName] = frozenset(
+    {
+        AnthropicModelName.CLAUDE_4_7_OPUS,
+        AnthropicModelName.CLAUDE_4_7_OPUS_LONG,
+    }
+)
+
 _ROLE_TO_ANTHROPIC_ROLE: Final[FrozenMapping[str, str]] = FrozenDict(
     {
         "HUMAN": "user",
@@ -505,7 +514,7 @@ class AnthropicAPI(LanguageModelAPI):
                         messages=non_system_messages,
                         stop_sequences=([params.stop] if params.stop is not None else NOT_GIVEN),
                         model=model_name,
-                        temperature=params.temperature,
+                        temperature=NOT_GIVEN if self.model_name in _MODELS_WITHOUT_TEMPERATURE else params.temperature,
                         system=prepend_claude_code_system_prompt(system_messages),
                         max_tokens=params.max_tokens,
                         betas=["context-1m-2025-08-07"],
@@ -519,7 +528,7 @@ class AnthropicAPI(LanguageModelAPI):
                         messages=non_system_messages,
                         stop_sequences=([params.stop] if params.stop is not None else NOT_GIVEN),
                         model=self.model_name,
-                        temperature=params.temperature,
+                        temperature=NOT_GIVEN if self.model_name in _MODELS_WITHOUT_TEMPERATURE else params.temperature,
                         system=prepend_claude_code_system_prompt(system_messages),
                         max_tokens=params.max_tokens,
                     )
@@ -600,7 +609,7 @@ class AnthropicAPI(LanguageModelAPI):
                     model=model_name,
                     stop_sequences=([params.stop] if params.stop is not None else NOT_GIVEN),
                     system=system_messages or NOT_GIVEN,
-                    temperature=params.temperature,
+                    temperature=NOT_GIVEN if self.model_name in _MODELS_WITHOUT_TEMPERATURE else params.temperature,
                 ) as stream:
                     async for text_delta in stream.text_stream:
                         yield LanguageModelStreamDeltaEvent(delta=text_delta)

--- a/vet/imbue_tools/types/vet_config.py
+++ b/vet/imbue_tools/types/vet_config.py
@@ -30,8 +30,8 @@ class VetConfig(SerializableModel):
     custom_guides_config: CustomGuidesConfig | None = None
 
     # Todo: Different models for different issue identifiers
-    language_model_generation_config: LanguageModelGenerationConfig = LanguageModelGenerationConfig(
-        model_name=AnthropicModelName.CLAUDE_4_6_OPUS
+    language_model_generation_config: LanguageModelGenerationConfig = (
+        LanguageModelGenerationConfig(model_name=AnthropicModelName.CLAUDE_4_7_OPUS)
     )
     max_identifier_spend_dollars: float | None = None
     max_output_tokens: int = 20000
@@ -75,7 +75,7 @@ class VetConfig(SerializableModel):
         cache_full_prompt: bool = False,
     ) -> "VetConfig":
         if not language_model_name:
-            language_model_name = AnthropicModelName.CLAUDE_4_6_OPUS
+            language_model_name = AnthropicModelName.CLAUDE_4_7_OPUS
         language_model_generation_config = LanguageModelGenerationConfig(
             model_name=language_model_name,
             cache_path=language_model_cache_path,
@@ -103,6 +103,10 @@ def get_enabled_issue_codes(config: VetConfig) -> set[IssueCode]:
     for code in explicitly_enabled + explicitly_disabled:
         if code not in all_issue_code_values:
             raise ValueError(f"Bad config: unknown issue code: {code}")
-    possibly_enabled_values = set(explicitly_enabled) if len(explicitly_enabled) > 0 else set(v for v in IssueCode)
+    possibly_enabled_values = (
+        set(explicitly_enabled)
+        if len(explicitly_enabled) > 0
+        else set(v for v in IssueCode)
+    )
     disabled_values = set(explicitly_disabled)
     return possibly_enabled_values - disabled_values

--- a/vet/imbue_tools/types/vet_config.py
+++ b/vet/imbue_tools/types/vet_config.py
@@ -30,8 +30,8 @@ class VetConfig(SerializableModel):
     custom_guides_config: CustomGuidesConfig | None = None
 
     # Todo: Different models for different issue identifiers
-    language_model_generation_config: LanguageModelGenerationConfig = (
-        LanguageModelGenerationConfig(model_name=AnthropicModelName.CLAUDE_4_7_OPUS)
+    language_model_generation_config: LanguageModelGenerationConfig = LanguageModelGenerationConfig(
+        model_name=AnthropicModelName.CLAUDE_4_7_OPUS
     )
     max_identifier_spend_dollars: float | None = None
     max_output_tokens: int = 20000
@@ -103,10 +103,6 @@ def get_enabled_issue_codes(config: VetConfig) -> set[IssueCode]:
     for code in explicitly_enabled + explicitly_disabled:
         if code not in all_issue_code_values:
             raise ValueError(f"Bad config: unknown issue code: {code}")
-    possibly_enabled_values = (
-        set(explicitly_enabled)
-        if len(explicitly_enabled) > 0
-        else set(v for v in IssueCode)
-    )
+    possibly_enabled_values = set(explicitly_enabled) if len(explicitly_enabled) > 0 else set(v for v in IssueCode)
     disabled_values = set(explicitly_disabled)
     return possibly_enabled_values - disabled_values


### PR DESCRIPTION
## Summary

- Add `claude-opus-4-7` and `claude-opus-4-7-long` model definitions with pricing from [Anthropic docs](https://docs.anthropic.com/en/docs/about-claude/models)
- Default model changed from `claude-opus-4-6` to `claude-opus-4-7`
- Opus 4.6 remains fully defined and selectable via `--model claude-opus-4-6`
