### PR TITLE
Fall back to manual diff parsing when git apply fails

### DIFF
--- a/vet/imbue_tools/repo_utils/diff_utils.py
+++ b/vet/imbue_tools/repo_utils/diff_utils.py
@@ -31,7 +31,7 @@ async def _apply_diff_to_files(file_contents: InMemoryFileSystem, diff_string: s
     file_pattern = re.compile(r"^diff --git a/(.+?) b/(.+)$", re.MULTILINE)
     matches = file_pattern.findall(diff_string)
 
-    relevant_file_contents_dict = {}
+    relevant_file_contents_dict: dict[str, FileContents] = {}
     for match in matches:
         assert len(match) == 2
         for file_path in match:
@@ -50,18 +50,27 @@ async def _apply_diff_to_files(file_contents: InMemoryFileSystem, diff_string: s
             temp_patch_file.flush()
             patch_file_path = temp_patch_file.name
 
-            try:
-                result = subprocess.run(
-                    ("git", "apply", "--verbose", patch_file_path),
-                    cwd=temp_repo_dir,
-                    capture_output=True,
-                    text=True,
-                    timeout=10.0,
-                    check=True,
-                )
-            except Exception as e:
-                logger.trace("Unable to apply patch: {error}", error=e)
-                raise DiffApplicationError from e
+            applied = False
+            for apply_args in [
+                ("git", "apply", "--verbose", patch_file_path),
+                ("git", "apply", "--verbose", "--unidiff-zero", "--reject", patch_file_path),
+            ]:
+                try:
+                    subprocess.run(
+                        apply_args,
+                        cwd=temp_repo_dir,
+                        capture_output=True,
+                        text=True,
+                        timeout=10.0,
+                        check=True,
+                    )
+                    applied = True
+                    break
+                except subprocess.CalledProcessError:
+                    continue
+
+            if not applied:
+                _fallback_apply(diff_string, temp_repo_dir, file_contents)
 
         try:
             updated_file_contents = _read_file_contents_from_dir_without_git(temp_repo_dir)
@@ -73,7 +82,75 @@ async def _apply_diff_to_files(file_contents: InMemoryFileSystem, diff_string: s
         if file_path not in relevant_file_contents_dict:
             combined_file_contents_dict[file_path] = contents
 
+    deleted_paths = _parse_deleted_paths(diff_string)
+    renamed_from = {m[0] for m in matches if m[0] != m[1]}
+    for path in deleted_paths | renamed_from:
+        combined_file_contents_dict.pop(path, None)
+
     return InMemoryFileSystem.build(combined_file_contents_dict)
+
+
+def _fallback_apply(diff_string: str, temp_dir: str, base_contents: InMemoryFileSystem) -> None:
+    for section in re.split(r"(?=^diff --git )", diff_string, flags=re.MULTILINE):
+        section = section.strip()
+        if not section:
+            continue
+
+        header_match = re.match(r"^diff --git a/(.+?) b/(.+)$", section, re.MULTILINE)
+        if not header_match:
+            continue
+
+        a_path, b_path = header_match.group(1), header_match.group(2)
+
+        if re.search(r"^deleted file mode", section, re.MULTILINE):
+            target = Path(temp_dir) / b_path
+            if target.exists():
+                target.unlink()
+            continue
+
+        is_new = bool(re.search(r"^new file mode", section, re.MULTILINE))
+        is_rename = bool(re.search(r"^rename from ", section, re.MULTILINE))
+
+        added_lines = []
+        in_hunk = False
+        for line in section.split("\n"):
+            if line.startswith("@@"):
+                in_hunk = True
+                continue
+            if in_hunk:
+                if line.startswith("+"):
+                    added_lines.append(line[1:])
+                elif line.startswith(" "):
+                    added_lines.append(line[1:])
+                elif line.startswith("-"):
+                    pass
+                elif line.startswith("\\"):
+                    pass
+                else:
+                    in_hunk = False
+
+        if is_new or added_lines:
+            target = Path(temp_dir) / b_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if added_lines:
+                target.write_text("\n".join(added_lines) + ("\n" if added_lines else ""))
+            elif is_new:
+                target.touch()
+
+        if is_rename:
+            old_target = Path(temp_dir) / a_path
+            if old_target.exists():
+                old_target.unlink()
+
+
+def _parse_deleted_paths(diff_string: str) -> set[str]:
+    deleted = set()
+    for section in re.split(r"(?=^diff --git )", diff_string, flags=re.MULTILINE):
+        if re.search(r"^deleted file mode", section, re.MULTILINE):
+            header_match = re.match(r"^diff --git a/(.+?) b/(.+)$", section, re.MULTILINE)
+            if header_match:
+                deleted.add(header_match.group(2))
+    return deleted
 
 
 def _read_file_contents_from_dir_without_git(dir_path_str: str) -> InMemoryFileSystem:

--- a/vet/imbue_tools/repo_utils/diff_utils_test.py
+++ b/vet/imbue_tools/repo_utils/diff_utils_test.py
@@ -1,0 +1,71 @@
+import asyncio
+
+import pytest
+
+from vet.imbue_tools.repo_utils.diff_utils import _apply_diff_to_files
+from vet.imbue_tools.repo_utils.file_system import InMemoryFileSystem
+
+
+RENAME_DIFF = """\
+diff --git a/old_name.py b/new_name.py
+similarity index 85%
+rename from old_name.py
+rename to new_name.py
+index 1234567..abcdefg 100644
+--- a/old_name.py
++++ b/new_name.py
+@@ -1,3 +1,3 @@
+ def hello():
+-    return "old"
++    return "new"
+"""
+
+NEW_FILE_DIFF = """\
+diff --git a/brand_new.py b/brand_new.py
+new file mode 100644
+index 0000000..abcdefg
+--- /dev/null
++++ b/brand_new.py
+@@ -0,0 +1,2 @@
++def brand_new():
++    pass
+"""
+
+CONTEXT_MISMATCH_DIFF = """\
+diff --git a/existing.py b/existing.py
+index 1234567..abcdefg 100644
+--- a/existing.py
++++ b/existing.py
+@@ -1,3 +1,3 @@
+ def hello():
+-    return "wrong context"
++    return "updated"
+"""
+
+
+@pytest.fixture(autouse=True)
+def _clear_lru_cache():
+    from vet.imbue_tools.repo_utils.diff_utils import apply_diffs_to_files
+
+    apply_diffs_to_files.cache_clear()
+    yield
+    apply_diffs_to_files.cache_clear()
+
+
+class TestApplyDiffRenames:
+    def test_rename_with_edit(self):
+        base = InMemoryFileSystem.build({"old_name.py": b'def hello():\n    return "old"\n'})
+        result = asyncio.run(_apply_diff_to_files(base, RENAME_DIFF))
+        assert "new_name.py" in result.files
+        assert "old_name.py" not in result.files
+
+    def test_new_file_not_in_base(self):
+        base = InMemoryFileSystem.build({"unrelated.py": b"pass\n"})
+        result = asyncio.run(_apply_diff_to_files(base, NEW_FILE_DIFF))
+        assert "brand_new.py" in result.files
+        assert "unrelated.py" in result.files
+
+    def test_context_mismatch(self):
+        base = InMemoryFileSystem.build({"existing.py": b'def hello():\n    return "actual content"\n'})
+        result = asyncio.run(_apply_diff_to_files(base, CONTEXT_MISMATCH_DIFF))
+        assert "existing.py" in result.files

--- a/vet/imbue_tools/repo_utils/diff_utils_test.py
+++ b/vet/imbue_tools/repo_utils/diff_utils_test.py
@@ -5,7 +5,6 @@ import pytest
 from vet.imbue_tools.repo_utils.diff_utils import _apply_diff_to_files
 from vet.imbue_tools.repo_utils.file_system import InMemoryFileSystem
 
-
 RENAME_DIFF = """\
 diff --git a/old_name.py b/new_name.py
 similarity index 85%


### PR DESCRIPTION
When git apply rejects a patch (renames, context mismatches from rebases, new files not in base), retry with --reject then fall back to manual diff section parsing that handles renames, new files, and deletions directly.