### PR TITLE
Fix fallback diff parser to merge hunks with base content

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1494,7 +1494,7 @@ wheels = [
 
 [[package]]
 name = "verify-everything"
-version = "0.2.9"
+version = "0.2.11"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/vet/imbue_tools/repo_utils/diff_utils.py
+++ b/vet/imbue_tools/repo_utils/diff_utils.py
@@ -70,6 +70,7 @@ async def _apply_diff_to_files(file_contents: InMemoryFileSystem, diff_string: s
                     continue
 
             if not applied:
+                logger.debug("git apply failed, using fallback diff parser")
                 _fallback_apply(diff_string, temp_repo_dir, file_contents)
 
         try:
@@ -109,38 +110,103 @@ def _fallback_apply(diff_string: str, temp_dir: str, base_contents: InMemoryFile
             continue
 
         is_new = bool(re.search(r"^new file mode", section, re.MULTILINE))
-        is_rename = bool(re.search(r"^rename from ", section, re.MULTILINE))
+        is_rename = a_path != b_path
 
-        added_lines = []
-        in_hunk = False
-        for line in section.split("\n"):
-            if line.startswith("@@"):
-                in_hunk = True
-                continue
-            if in_hunk:
-                if line.startswith("+"):
-                    added_lines.append(line[1:])
-                elif line.startswith(" "):
-                    added_lines.append(line[1:])
-                elif line.startswith("-"):
-                    pass
-                elif line.startswith("\\"):
-                    pass
-                else:
-                    in_hunk = False
+        hunks = _parse_hunks(section)
 
-        if is_new or added_lines:
+        if is_new:
+            new_lines: list[str] = []
+            for _, _, additions in hunks:
+                new_lines.extend(additions)
             target = Path(temp_dir) / b_path
             target.parent.mkdir(parents=True, exist_ok=True)
-            if added_lines:
-                target.write_text("\n".join(added_lines) + ("\n" if added_lines else ""))
-            elif is_new:
-                target.touch()
+            target.write_text("\n".join(new_lines) + "\n" if new_lines else "")
+        elif hunks:
+            base_text = _get_base_text(a_path, temp_dir, base_contents)
+            base_lines = base_text.splitlines() if base_text else []
+            result_lines = _apply_hunks_to_lines(base_lines, hunks)
+            target = Path(temp_dir) / b_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("\n".join(result_lines) + "\n" if result_lines else "")
+        elif is_rename:
+            base_bytes = base_contents.get(a_path)
+            target = Path(temp_dir) / b_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if base_bytes is not None and isinstance(base_bytes, bytes):
+                target.write_bytes(base_bytes)
+            elif (Path(temp_dir) / a_path).exists():
+                target.write_bytes((Path(temp_dir) / a_path).read_bytes())
 
         if is_rename:
             old_target = Path(temp_dir) / a_path
             if old_target.exists():
                 old_target.unlink()
+
+
+def _get_base_text(path: str, temp_dir: str, base_contents: InMemoryFileSystem) -> str:
+    base_bytes = base_contents.get(path)
+    if base_bytes is not None and isinstance(base_bytes, bytes):
+        try:
+            return base_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            return ""
+    on_disk = Path(temp_dir) / path
+    if on_disk.exists():
+        return on_disk.read_text()
+    return ""
+
+
+def _parse_hunks(section: str) -> list[tuple[int, int, list[str]]]:
+    hunks: list[tuple[int, int, list[str]]] = []
+    hunk_header_re = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+    current_start = 0
+    current_count = 0
+    new_lines: list[str] = []
+
+    lines = section.split("\n")
+    i = 0
+    while i < len(lines):
+        m = hunk_header_re.match(lines[i])
+        if m:
+            if current_start or new_lines:
+                hunks.append((current_start, current_count, new_lines))
+            current_start = int(m.group(1))
+            current_count = int(m.group(2)) if m.group(2) else 1
+            new_lines = []
+            i += 1
+            while i < len(lines):
+                line = lines[i]
+                if line.startswith("@@") or line.startswith("diff --git"):
+                    break
+                if line.startswith("+"):
+                    new_lines.append(line[1:])
+                elif line.startswith(" "):
+                    new_lines.append(line[1:])
+                elif line.startswith("-"):
+                    pass
+                elif line.startswith("\\"):
+                    pass
+                else:
+                    break
+                i += 1
+            continue
+        i += 1
+
+    if current_start or new_lines:
+        hunks.append((current_start, current_count, new_lines))
+
+    return hunks
+
+
+def _apply_hunks_to_lines(base_lines: list[str], hunks: list[tuple[int, int, list[str]]]) -> list[str]:
+    result = list(base_lines)
+    offset = 0
+    for start, count, new_lines in hunks:
+        idx = start - 1 + offset
+        end_idx = idx + count
+        result[idx:end_idx] = new_lines
+        offset += len(new_lines) - count
+    return result
 
 
 def _parse_deleted_paths(diff_string: str) -> set[str]:

--- a/vet/imbue_tools/repo_utils/diff_utils_test.py
+++ b/vet/imbue_tools/repo_utils/diff_utils_test.py
@@ -19,6 +19,13 @@ index 1234567..abcdefg 100644
 +    return "new"
 """
 
+PURE_RENAME_DIFF = """\
+diff --git a/before.py b/after.py
+similarity index 100%
+rename from before.py
+rename to after.py
+"""
+
 NEW_FILE_DIFF = """\
 diff --git a/brand_new.py b/brand_new.py
 new file mode 100644
@@ -41,6 +48,29 @@ index 1234567..abcdefg 100644
 +    return "updated"
 """
 
+PARTIAL_EDIT_DIFF_MISMATCHED = """\
+diff --git a/big_file.py b/big_file.py
+index 1234567..abcdefg 100644
+--- a/big_file.py
++++ b/big_file.py
+@@ -3,3 +3,3 @@
+ wrong_context_line3
+-wrong_context_line4
++line4_modified
+ wrong_context_line5
+"""
+
+DELETE_DIFF = """\
+diff --git a/doomed.py b/doomed.py
+deleted file mode 100644
+index abcdefg..0000000
+--- a/doomed.py
++++ /dev/null
+@@ -1,2 +0,0 @@
+-def doomed():
+-    pass
+"""
+
 
 @pytest.fixture(autouse=True)
 def _clear_lru_cache():
@@ -51,20 +81,59 @@ def _clear_lru_cache():
     apply_diffs_to_files.cache_clear()
 
 
-class TestApplyDiffRenames:
+class TestApplyDiffFallback:
     def test_rename_with_edit(self):
         base = InMemoryFileSystem.build({"old_name.py": b'def hello():\n    return "old"\n'})
         result = asyncio.run(_apply_diff_to_files(base, RENAME_DIFF))
         assert "new_name.py" in result.files
         assert "old_name.py" not in result.files
+        text = result.files["new_name.py"].decode() if isinstance(result.files["new_name.py"], bytes) else ""
+        assert "def hello():" in text
+        assert "new" in text
 
-    def test_new_file_not_in_base(self):
+    def test_pure_rename_preserves_content(self):
+        content = b"original content\nline two\n"
+        base = InMemoryFileSystem.build({"before.py": content})
+        result = asyncio.run(_apply_diff_to_files(base, PURE_RENAME_DIFF))
+        assert "after.py" in result.files
+        assert "before.py" not in result.files
+        assert result.files["after.py"] == content
+
+    def test_new_file_content(self):
         base = InMemoryFileSystem.build({"unrelated.py": b"pass\n"})
         result = asyncio.run(_apply_diff_to_files(base, NEW_FILE_DIFF))
-        assert "brand_new.py" in result.files
-        assert "unrelated.py" in result.files
+        text = result.files["brand_new.py"].decode() if isinstance(result.files["brand_new.py"], bytes) else ""
+        assert "def brand_new():" in text
+        assert "pass" in text
+        assert result.files["unrelated.py"] == b"pass\n"
 
-    def test_context_mismatch(self):
+    def test_context_mismatch_preserves_context_lines(self):
         base = InMemoryFileSystem.build({"existing.py": b'def hello():\n    return "actual content"\n'})
         result = asyncio.run(_apply_diff_to_files(base, CONTEXT_MISMATCH_DIFF))
-        assert "existing.py" in result.files
+        text = result.files["existing.py"].decode() if isinstance(result.files["existing.py"], bytes) else ""
+        assert "updated" in text
+        assert "def hello():" in text
+
+    def test_partial_edit_preserves_all_lines(self):
+        base_content = b"line1\nline2\nline3\nline4\nline5\nline6\nline7\n"
+        base = InMemoryFileSystem.build({"big_file.py": base_content})
+        result = asyncio.run(_apply_diff_to_files(base, PARTIAL_EDIT_DIFF_MISMATCHED))
+        text = result.files["big_file.py"].decode() if isinstance(result.files["big_file.py"], bytes) else ""
+        assert "line1" in text
+        assert "line2" in text
+        assert "line3" in text
+        assert "line4_modified" in text
+        assert "line5" in text
+        assert "line6" in text
+        assert "line7" in text
+
+    def test_delete_removes_file(self):
+        base = InMemoryFileSystem.build(
+            {
+                "doomed.py": b"def doomed():\n    pass\n",
+                "keeper.py": b"keep\n",
+            }
+        )
+        result = asyncio.run(_apply_diff_to_files(base, DELETE_DIFF))
+        assert "doomed.py" not in result.files
+        assert "keeper.py" in result.files


### PR DESCRIPTION
The fallback diff parser rewrote files using only hunk lines, truncating content outside the hunks. Now merges hunks into the full base file content using line offsets from hunk headers. Also fixes pure renames (100% similarity, no hunks) losing file content, and adds logging when the fallback path runs.