### PR TITLE
Add claude-opus-4-8 support

### DIFF
--- a/.vet/models.json
+++ b/.vet/models.json
@@ -56,8 +56,14 @@
           "max_output_tokens": 128000,
           "supports_temperature": true
         },
-        "opus": {
+        "opus-4.7": {
           "model_id": "claude-opus-4-7",
+          "context_window": 200000,
+          "max_output_tokens": 128000,
+          "supports_temperature": false
+        },
+        "opus": {
+          "model_id": "claude-opus-4-8",
           "context_window": 200000,
           "max_output_tokens": 128000,
           "supports_temperature": false

--- a/skills/vet/SKILL.md
+++ b/skills/vet/SKILL.md
@@ -99,7 +99,7 @@ Vet analyzes the full git diff from the base commit. This may include changes fr
 ## Common Options
 
 - `--base-commit REF`: Git ref for diff base (default: HEAD)
-- `--model MODEL`: LLM to use (default: claude-opus-4-7)
+- `--model MODEL`: LLM to use (default: claude-opus-4-8)
 - `--list-models`: list all models that are supported by vet
     - Run `vet --help` and look at the vet repo's readme for details about defining custom OpenAI-compatible models.
 - `--update-models`: fetch the latest community model definitions from the remote registry and cache them locally. See "Updating the Model Registry" below for when to run this.

--- a/vet/cli/main.py
+++ b/vet/cli/main.py
@@ -152,7 +152,7 @@ def create_parser() -> argparse.ArgumentParser:
         default=CLI_DEFAULTS.model,
         metavar="MODEL",
         # Hardcoded to avoid importing cli.models at module level (~1s of SDK imports).
-        help="LLM to use for analysis (default: claude-opus-4-7).",
+        help="LLM to use for analysis (default: claude-opus-4-8).",
     )
     model_group.add_argument(
         "--list-models",

--- a/vet/cli/models.py
+++ b/vet/cli/models.py
@@ -12,7 +12,7 @@ from vet.imbue_core.agents.llm_apis.common import get_all_model_names
 from vet.imbue_core.agents.llm_apis.gemini_api import GeminiModelName
 from vet.imbue_core.agents.llm_apis.openai_api import OpenAIModelName
 
-DEFAULT_MODEL_ID = AnthropicModelName.CLAUDE_4_7_OPUS.value
+DEFAULT_MODEL_ID = AnthropicModelName.CLAUDE_4_8_OPUS.value
 
 
 class MissingProviderAPIKeyError(Exception):

--- a/vet/imbue_core/agents/llm_apis/anthropic_api.py
+++ b/vet/imbue_core/agents/llm_apis/anthropic_api.py
@@ -60,6 +60,7 @@ class AnthropicModelName(enum.StrEnum):
     CLAUDE_4_5_OPUS = "claude-opus-4-5"
     CLAUDE_4_6_OPUS = "claude-opus-4-6"
     CLAUDE_4_7_OPUS = "claude-opus-4-7"
+    CLAUDE_4_8_OPUS = "claude-opus-4-8"
     CLAUDE_4_SONNET = "claude-sonnet-4-0"
     CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
     CLAUDE_4_6_SONNET = "claude-sonnet-4-6"
@@ -71,6 +72,7 @@ class AnthropicModelName(enum.StrEnum):
     CLAUDE_4_5_SONNET_LONG = "claude-sonnet-4-5-long"
     CLAUDE_4_6_OPUS_LONG = "claude-opus-4-6-long"
     CLAUDE_4_7_OPUS_LONG = "claude-opus-4-7-long"
+    CLAUDE_4_8_OPUS_LONG = "claude-opus-4-8-long"
 
 
 # Basic info is available at https://docs.anthropic.com/claude/reference/models
@@ -142,6 +144,21 @@ ANTHROPIC_MODEL_INFO_BY_NAME: FrozenMapping[AnthropicModelName, ModelInfo] = Fro
         ),
         AnthropicModelName.CLAUDE_4_7_OPUS: ModelInfo(
             model_name=AnthropicModelName.CLAUDE_4_7_OPUS,
+            cost_per_input_token=5.00 / 1_000_000,
+            cost_per_output_token=25.00 / 1_000_000,
+            max_input_tokens=200_000,
+            max_output_tokens=128_000,
+            rate_limit_req=4000 / 60,
+            rate_limit_tok=2_000_000 / 60,
+            rate_limit_output_tok=400_000 / 60,
+            provider_specific_info=AnthropicModelInfo(
+                cost_per_5m_cache_write_token=6.25 / 1_000_000,
+                cost_per_1h_cache_write_token=10 / 1_000_000,
+                cost_per_cache_read_token=0.50 / 1_000_000,
+            ),
+        ),
+        AnthropicModelName.CLAUDE_4_8_OPUS: ModelInfo(
+            model_name=AnthropicModelName.CLAUDE_4_8_OPUS,
             cost_per_input_token=5.00 / 1_000_000,
             cost_per_output_token=25.00 / 1_000_000,
             max_input_tokens=200_000,
@@ -265,6 +282,17 @@ ANTHROPIC_MODEL_INFO_BY_NAME: FrozenMapping[AnthropicModelName, ModelInfo] = Fro
             rate_limit_tok=1_000_000 / 60,
             rate_limit_output_tok=200_000 / 60,
         ),
+        AnthropicModelName.CLAUDE_4_8_OPUS_LONG: ModelInfo(
+            model_name=AnthropicModelName.CLAUDE_4_8_OPUS_LONG,
+            # Opus 4.8 has a native 1M context window. Pricing tiers match 4.7 long-context.
+            cost_per_input_token=9.00 / 1_000_000,
+            cost_per_output_token=37.50 / 1_000_000,
+            max_input_tokens=1_000_000,
+            max_output_tokens=128_000,
+            rate_limit_req=None,  # Currently no limit set in our dashboard
+            rate_limit_tok=1_000_000 / 60,
+            rate_limit_output_tok=200_000 / 60,
+        ),
     }
 )
 
@@ -275,6 +303,8 @@ _MODELS_WITHOUT_TEMPERATURE: frozenset[AnthropicModelName] = frozenset(
     {
         AnthropicModelName.CLAUDE_4_7_OPUS,
         AnthropicModelName.CLAUDE_4_7_OPUS_LONG,
+        AnthropicModelName.CLAUDE_4_8_OPUS,
+        AnthropicModelName.CLAUDE_4_8_OPUS_LONG,
     }
 )
 
@@ -504,6 +534,7 @@ class AnthropicAPI(LanguageModelAPI):
                     AnthropicModelName.CLAUDE_4_SONNET_LONG: AnthropicModelName.CLAUDE_4_SONNET,
                     AnthropicModelName.CLAUDE_4_6_OPUS_LONG: AnthropicModelName.CLAUDE_4_6_OPUS,
                     AnthropicModelName.CLAUDE_4_7_OPUS_LONG: AnthropicModelName.CLAUDE_4_7_OPUS,
+                    AnthropicModelName.CLAUDE_4_8_OPUS_LONG: AnthropicModelName.CLAUDE_4_8_OPUS,
                 }
 
                 if self.model_name in _LONG_TO_STANDARD:
@@ -585,6 +616,7 @@ class AnthropicAPI(LanguageModelAPI):
                     AnthropicModelName.CLAUDE_4_SONNET_LONG: AnthropicModelName.CLAUDE_4_SONNET,
                     AnthropicModelName.CLAUDE_4_6_OPUS_LONG: AnthropicModelName.CLAUDE_4_6_OPUS,
                     AnthropicModelName.CLAUDE_4_7_OPUS_LONG: AnthropicModelName.CLAUDE_4_7_OPUS,
+                    AnthropicModelName.CLAUDE_4_8_OPUS_LONG: AnthropicModelName.CLAUDE_4_8_OPUS,
                 }
 
                 if self.model_name in _LONG_TO_STANDARD_STREAM:

--- a/vet/imbue_tools/types/vet_config.py
+++ b/vet/imbue_tools/types/vet_config.py
@@ -31,7 +31,7 @@ class VetConfig(SerializableModel):
 
     # Todo: Different models for different issue identifiers
     language_model_generation_config: LanguageModelGenerationConfig = LanguageModelGenerationConfig(
-        model_name=AnthropicModelName.CLAUDE_4_7_OPUS
+        model_name=AnthropicModelName.CLAUDE_4_8_OPUS
     )
     max_identifier_spend_dollars: float | None = None
     max_output_tokens: int = 20000
@@ -75,7 +75,7 @@ class VetConfig(SerializableModel):
         cache_full_prompt: bool = False,
     ) -> "VetConfig":
         if not language_model_name:
-            language_model_name = AnthropicModelName.CLAUDE_4_7_OPUS
+            language_model_name = AnthropicModelName.CLAUDE_4_8_OPUS
         language_model_generation_config = LanguageModelGenerationConfig(
             model_name=language_model_name,
             cache_path=language_model_cache_path,


### PR DESCRIPTION
Adds Claude Opus 4.8 as a built-in model and updates the default from 4.7 to 4.8.

Changes:
- Add CLAUDE_4_8_OPUS and CLAUDE_4_8_OPUS_LONG to AnthropicModelName enum
- Add model info entries with pricing ($5/$25 per MTok, 1M context, 128k output)
- Add to _MODELS_WITHOUT_TEMPERATURE (adaptive thinking, same as 4.7)
- Add to both long-context model mappings for 1M context support
- Update DEFAULT_MODEL_ID to claude-opus-4-8
- Update .vet/models.json: rename opus alias to 4.8, keep 4.7 as opus-4.7

Tested with vet runs using both the native Anthropic connector (claude-opus-4-8) and the OpenAI-compatible connector (opus alias). Both work correctly.