### PR TITLE
Add claude-fable-5 support

### DIFF
--- a/.vet/models.json
+++ b/.vet/models.json
@@ -70,7 +70,7 @@
         },
         "fable": {
           "model_id": "claude-fable-5",
-          "context_window": 200000,
+          "context_window": 1000000,
           "max_output_tokens": 128000,
           "supports_temperature": false
         }

--- a/.vet/models.json
+++ b/.vet/models.json
@@ -67,6 +67,12 @@
           "context_window": 200000,
           "max_output_tokens": 128000,
           "supports_temperature": false
+        },
+        "fable": {
+          "model_id": "claude-fable-5",
+          "context_window": 200000,
+          "max_output_tokens": 128000,
+          "supports_temperature": false
         }
       }
     },

--- a/registry/models.json
+++ b/registry/models.json
@@ -31,6 +31,20 @@
           "supports_temperature": true
         }
       }
+    },
+    "anthropic": {
+      "name": "Anthropic",
+      "api_type": "openai_compatible",
+      "base_url": "https://api.anthropic.com/v1/",
+      "api_key_env": "ANTHROPIC_API_KEY",
+      "models": {
+        "fable": {
+          "model_id": "claude-fable-5",
+          "context_window": 200000,
+          "max_output_tokens": 128000,
+          "supports_temperature": false
+        }
+      }
     }
   }
 }

--- a/registry/models.json
+++ b/registry/models.json
@@ -40,7 +40,7 @@
       "models": {
         "fable": {
           "model_id": "claude-fable-5",
-          "context_window": 200000,
+          "context_window": 1000000,
           "max_output_tokens": 128000,
           "supports_temperature": false
         }

--- a/vet/cli/main.py
+++ b/vet/cli/main.py
@@ -601,6 +601,7 @@ def main(argv: list[str] | None = None) -> int:
     from vet.formatters import issue_to_dict
     from vet.imbue_core.agents.llm_apis.errors import BadAPIRequestError
     from vet.imbue_core.agents.llm_apis.errors import MissingAPIKeyError
+    from vet.imbue_core.agents.llm_apis.errors import ModelRefusalError
     from vet.imbue_core.agents.llm_apis.errors import PromptTooLongError
     from vet.imbue_tools.types.vet_config import VetConfig
 
@@ -733,6 +734,13 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 2
+    except ModelRefusalError as e:
+        print(
+            f"vet: {e} This can happen spuriously on benign inputs; "
+            "try re-running, or use a different model via --model.",
+            file=sys.stderr,
+        )
+        return 1
     # TODO: This should be refactored so we only need to handle prompt too long errors when context is overfilled.
     except (PromptTooLongError, BadAPIRequestError) as e:
         if _is_context_overflow(e):

--- a/vet/cli/main_test.py
+++ b/vet/cli/main_test.py
@@ -145,3 +145,38 @@ class TestListModels:
         captured = capsys.readouterr()
         assert "remote-model-a" in captured.out
         assert "remote-model-b" in captured.out
+
+
+class TestModelRefusal:
+    """CLI integration tests for surfacing model refusals."""
+
+    def test_model_refusal_prints_error_and_returns_1(self, tmp_path: Path, capsys) -> None:
+        import subprocess
+
+        from vet.imbue_core.agents.llm_apis.errors import ModelRefusalError
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "init"],
+            cwd=repo,
+            check=True,
+        )
+
+        env = _env_for_isolated_config(tmp_path) | {"ANTHROPIC_API_KEY": "test-key"}
+        refusal = ModelRefusalError(
+            "The model refused to generate a response (the provider's safety classifiers declined the request)."
+        )
+
+        with patch.dict(os.environ, env):
+            # configure_logging would tear down the logging handlers installed by test fixtures.
+            with patch("vet.cli.main.configure_logging"):
+                with patch("vet.api.find_issues", side_effect=refusal):
+                    exit_code = main(["test goal", "--repo", str(repo), "--quiet"])
+
+        assert exit_code == 1
+
+        captured = capsys.readouterr()
+        assert "refused" in captured.err
+        assert "try re-running" in captured.err

--- a/vet/imbue_core/agents/llm_apis/anthropic_api.py
+++ b/vet/imbue_core/agents/llm_apis/anthropic_api.py
@@ -33,6 +33,7 @@ from vet.imbue_core.agents.llm_apis.data_types import ResponseStopReason
 from vet.imbue_core.agents.llm_apis.errors import BadAPIRequestError
 from vet.imbue_core.agents.llm_apis.errors import LanguageModelInvalidModelNameError
 from vet.imbue_core.agents.llm_apis.errors import MissingAPIKeyError
+from vet.imbue_core.agents.llm_apis.errors import ModelRefusalError
 from vet.imbue_core.agents.llm_apis.errors import NewSeedRetriableLanguageModelError
 from vet.imbue_core.agents.llm_apis.errors import SafelyRetriableTransientLanguageModelError
 from vet.imbue_core.agents.llm_apis.errors import TransientLanguageModelError
@@ -340,14 +341,16 @@ def _extract_text_from_content_blocks(content_blocks: list, stop_reason: str | N
     ``only(content).text`` behavior.
 
     Fable 5's safety classifiers can also produce a ``refusal`` stop reason with *no* content blocks
-    at all. In that case we return an empty string and let the caller propagate the refusal via the
-    stop reason, rather than raising. We only raise when the response is missing text for some other,
-    unexpected reason (which would indicate a real problem rather than a refusal).
+    at all. In that case we raise ModelRefusalError so the refusal is surfaced to the user instead
+    of being silently treated as an empty (clean) review result. Missing text for any other reason
+    indicates a malformed response and raises BadAPIRequestError.
     """
     text_blocks = [block.text for block in content_blocks if getattr(block, "type", None) == "text"]
     if not text_blocks:
         if stop_reason == "refusal":
-            return ""
+            raise ModelRefusalError(
+                "The model refused to generate a response (the provider's safety classifiers " "declined the request)."
+            )
         raise BadAPIRequestError(
             f"Anthropic response contained no text content blocks (block types: "
             f"{[getattr(block, 'type', None) for block in content_blocks]}, stop_reason: {stop_reason})"
@@ -484,7 +487,7 @@ def _anthropic_exception_manager() -> Iterator[None]:
     except httpx.RemoteProtocolError as e:
         logger.debug(str(e))
         raise TransientLanguageModelError("httpx.RemoteProtocolError") from e
-    except (BadAPIRequestError, TransientLanguageModelError, MissingAPIKeyError):
+    except (BadAPIRequestError, TransientLanguageModelError, MissingAPIKeyError, ModelRefusalError):
         # we already raised this error ourselves earlier, so we don't need to mark it as unknown
         raise
     except Exception as e:
@@ -506,10 +509,21 @@ class AnthropicAPI(LanguageModelAPI):
     is_conversational: bool = True
 
     # Anthropic specific args
-    # unclear what the timeout ought to be actually, set to 1 minute for now because their default of 10 minutes seems insane
-    timeout: float = 60.0
+    # None means "use the per-model default" (see _get_timeout). Most models use 1 minute because
+    # the SDK default of 10 minutes seems insane. Claude Fable 5 uses a much longer timeout: its
+    # adaptive thinking is always on and counts toward output, so responses to review-sized prompts
+    # routinely take 3+ minutes to generate (measured ~190-210s for ~70k-token prompts). A 60s
+    # timeout would abort (and re-bill) requests that were going to succeed.
+    timeout: float | None = None
     max_retries: int = 0
     count_tokens_cache_path: Path | None = None
+
+    def _get_timeout(self) -> float:
+        if self.timeout is not None:
+            return self.timeout
+        if self.model_name == AnthropicModelName.CLAUDE_FABLE_5:
+            return 600.0
+        return 60.0
 
     @field_validator("model_name")  # pyre-ignore[56]: pyre doesn't understand pydantic
     @classmethod
@@ -538,14 +552,14 @@ class AnthropicAPI(LanguageModelAPI):
             return anthropic.AsyncAnthropic(
                 api_key=api_key,
                 max_retries=self.max_retries,
-                timeout=self.timeout,
+                timeout=self._get_timeout(),
                 default_headers={"anthropic-beta": _ANTHROPIC_BETA_PROMPT_CACHING},
             )
         else:
             return anthropic.AsyncAnthropic(
                 auth_token=auth_token,
                 max_retries=self.max_retries,
-                timeout=self.timeout,
+                timeout=self._get_timeout(),
                 default_headers={"anthropic-beta": f"{_ANTHROPIC_BETA_PROMPT_CACHING},{_ANTHROPIC_BETA_OAUTH}"},
             )
 

--- a/vet/imbue_core/agents/llm_apis/anthropic_api.py
+++ b/vet/imbue_core/agents/llm_apis/anthropic_api.py
@@ -60,6 +60,8 @@ class AnthropicModelName(enum.StrEnum):
     CLAUDE_4_6_OPUS = "claude-opus-4-6"
     CLAUDE_4_7_OPUS = "claude-opus-4-7"
     CLAUDE_4_8_OPUS = "claude-opus-4-8"
+    # Fable 5 is a Mythos-class model with a native 1M-token context window, so it does not need a
+    # separate "-long" variant the way the Opus models do.
     CLAUDE_FABLE_5 = "claude-fable-5"
     CLAUDE_4_SONNET = "claude-sonnet-4-0"
     CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
@@ -73,7 +75,6 @@ class AnthropicModelName(enum.StrEnum):
     CLAUDE_4_6_OPUS_LONG = "claude-opus-4-6-long"
     CLAUDE_4_7_OPUS_LONG = "claude-opus-4-7-long"
     CLAUDE_4_8_OPUS_LONG = "claude-opus-4-8-long"
-    CLAUDE_FABLE_5_LONG = "claude-fable-5-long"
 
 
 # Basic info is available at https://docs.anthropic.com/claude/reference/models
@@ -175,9 +176,12 @@ ANTHROPIC_MODEL_INFO_BY_NAME: FrozenMapping[AnthropicModelName, ModelInfo] = Fro
         ),
         AnthropicModelName.CLAUDE_FABLE_5: ModelInfo(
             model_name=AnthropicModelName.CLAUDE_FABLE_5,
+            # Fable 5 has a native 1M-token context window (verified against the API: inputs above
+            # 200k are accepted without any beta header, and the API rejects prompts over 1,000,000
+            # tokens). Pricing is a flat $10 / $50 per 1M tokens with no long-context tier.
             cost_per_input_token=10.00 / 1_000_000,
             cost_per_output_token=50.00 / 1_000_000,
-            max_input_tokens=200_000,
+            max_input_tokens=1_000_000,
             max_output_tokens=128_000,
             rate_limit_req=4000 / 60,
             rate_limit_tok=2_000_000 / 60,
@@ -309,20 +313,6 @@ ANTHROPIC_MODEL_INFO_BY_NAME: FrozenMapping[AnthropicModelName, ModelInfo] = Fro
             rate_limit_tok=1_000_000 / 60,
             rate_limit_output_tok=200_000 / 60,
         ),
-        AnthropicModelName.CLAUDE_FABLE_5_LONG: ModelInfo(
-            model_name=AnthropicModelName.CLAUDE_FABLE_5_LONG,
-            # Fable 5 has a native 1M context window. Long-context pricing tiers mirror the Opus
-            # long-context multipliers: the first 200_000 input tokens use the 10.0 / 1_000_000 rate
-            # and the next up to 800_000 use 20.0 / 1_000_000, so the maximum average cost per input
-            # token is (10.0 * 200_000 + 20.0 * 800_000) / 1_000_000 = 18.0 per 1_000_000.
-            cost_per_input_token=18.00 / 1_000_000,
-            cost_per_output_token=75.00 / 1_000_000,
-            max_input_tokens=1_000_000,
-            max_output_tokens=128_000,
-            rate_limit_req=None,  # Currently no limit set in our dashboard
-            rate_limit_tok=1_000_000 / 60,
-            rate_limit_output_tok=200_000 / 60,
-        ),
     }
 )
 
@@ -336,12 +326,11 @@ _MODELS_WITHOUT_TEMPERATURE: frozenset[AnthropicModelName] = frozenset(
         AnthropicModelName.CLAUDE_4_8_OPUS,
         AnthropicModelName.CLAUDE_4_8_OPUS_LONG,
         AnthropicModelName.CLAUDE_FABLE_5,
-        AnthropicModelName.CLAUDE_FABLE_5_LONG,
     }
 )
 
 
-def _extract_text_from_content_blocks(content_blocks: list) -> str:
+def _extract_text_from_content_blocks(content_blocks: list, stop_reason: str | None = None) -> str:
     """Concatenate the text from all ``text`` content blocks in an Anthropic message.
 
     Some models (e.g. Claude Fable 5) emit a ``thinking`` block before the final ``text`` block even
@@ -349,12 +338,19 @@ def _extract_text_from_content_blocks(content_blocks: list) -> str:
     content block. We ignore non-text blocks (``thinking``, ``redacted_thinking``, etc.) and return
     only the visible text. For responses with a single ``text`` block this matches the previous
     ``only(content).text`` behavior.
+
+    Fable 5's safety classifiers can also produce a ``refusal`` stop reason with *no* content blocks
+    at all. In that case we return an empty string and let the caller propagate the refusal via the
+    stop reason, rather than raising. We only raise when the response is missing text for some other,
+    unexpected reason (which would indicate a real problem rather than a refusal).
     """
     text_blocks = [block.text for block in content_blocks if getattr(block, "type", None) == "text"]
     if not text_blocks:
+        if stop_reason == "refusal":
+            return ""
         raise BadAPIRequestError(
             f"Anthropic response contained no text content blocks (block types: "
-            f"{[getattr(block, 'type', None) for block in content_blocks]})"
+            f"{[getattr(block, 'type', None) for block in content_blocks]}, stop_reason: {stop_reason})"
         )
     return "".join(text_blocks)
 
@@ -586,7 +582,6 @@ class AnthropicAPI(LanguageModelAPI):
                     AnthropicModelName.CLAUDE_4_6_OPUS_LONG: AnthropicModelName.CLAUDE_4_6_OPUS,
                     AnthropicModelName.CLAUDE_4_7_OPUS_LONG: AnthropicModelName.CLAUDE_4_7_OPUS,
                     AnthropicModelName.CLAUDE_4_8_OPUS_LONG: AnthropicModelName.CLAUDE_4_8_OPUS,
-                    AnthropicModelName.CLAUDE_FABLE_5_LONG: AnthropicModelName.CLAUDE_FABLE_5,
                 }
 
                 if self.model_name in _LONG_TO_STANDARD:
@@ -619,7 +614,10 @@ class AnthropicAPI(LanguageModelAPI):
                         written_5m=api_result.usage.cache_creation.ephemeral_5m_input_tokens,
                         written_1h=api_result.usage.cache_creation.ephemeral_1h_input_tokens,
                     )
-                text = _extract_text_from_content_blocks(api_result.content)
+                text = _extract_text_from_content_blocks(
+                    api_result.content,
+                    stop_reason=str(api_result.stop_reason) if api_result.stop_reason else None,
+                )
                 if api_result.stop_reason:
                     stop_reason = _ANTHROPIC_STOP_REASON_TO_STOP_REASON.get(
                         str(api_result.stop_reason), ResponseStopReason.NONE
@@ -669,7 +667,6 @@ class AnthropicAPI(LanguageModelAPI):
                     AnthropicModelName.CLAUDE_4_6_OPUS_LONG: AnthropicModelName.CLAUDE_4_6_OPUS,
                     AnthropicModelName.CLAUDE_4_7_OPUS_LONG: AnthropicModelName.CLAUDE_4_7_OPUS,
                     AnthropicModelName.CLAUDE_4_8_OPUS_LONG: AnthropicModelName.CLAUDE_4_8_OPUS,
-                    AnthropicModelName.CLAUDE_FABLE_5_LONG: AnthropicModelName.CLAUDE_FABLE_5,
                 }
 
                 if self.model_name in _LONG_TO_STANDARD_STREAM:
@@ -700,7 +697,10 @@ class AnthropicAPI(LanguageModelAPI):
                         yield LanguageModelStreamDeltaEvent(delta=text_delta)
 
                     final_message = await stream.get_final_message()
-                    text = _extract_text_from_content_blocks(final_message.content)
+                    text = _extract_text_from_content_blocks(
+                        final_message.content,
+                        stop_reason=str(final_message.stop_reason) if final_message.stop_reason else None,
+                    )
                     stop_reason = (
                         final_message.stop_reason if final_message.stop_reason is not None else ResponseStopReason.NONE
                     )

--- a/vet/imbue_core/agents/llm_apis/anthropic_api.py
+++ b/vet/imbue_core/agents/llm_apis/anthropic_api.py
@@ -47,7 +47,6 @@ from vet.imbue_core.async_monkey_patches import log_exception
 from vet.imbue_core.caching import AsyncCache
 from vet.imbue_core.frozen_utils import FrozenDict
 from vet.imbue_core.frozen_utils import FrozenMapping
-from vet.imbue_core.itertools import only
 from vet.imbue_core.nested_evolver import assign
 from vet.imbue_core.nested_evolver import chill
 from vet.imbue_core.nested_evolver import evolver
@@ -61,6 +60,7 @@ class AnthropicModelName(enum.StrEnum):
     CLAUDE_4_6_OPUS = "claude-opus-4-6"
     CLAUDE_4_7_OPUS = "claude-opus-4-7"
     CLAUDE_4_8_OPUS = "claude-opus-4-8"
+    CLAUDE_FABLE_5 = "claude-fable-5"
     CLAUDE_4_SONNET = "claude-sonnet-4-0"
     CLAUDE_4_5_SONNET = "claude-sonnet-4-5"
     CLAUDE_4_6_SONNET = "claude-sonnet-4-6"
@@ -73,6 +73,7 @@ class AnthropicModelName(enum.StrEnum):
     CLAUDE_4_6_OPUS_LONG = "claude-opus-4-6-long"
     CLAUDE_4_7_OPUS_LONG = "claude-opus-4-7-long"
     CLAUDE_4_8_OPUS_LONG = "claude-opus-4-8-long"
+    CLAUDE_FABLE_5_LONG = "claude-fable-5-long"
 
 
 # Basic info is available at https://docs.anthropic.com/claude/reference/models
@@ -170,6 +171,21 @@ ANTHROPIC_MODEL_INFO_BY_NAME: FrozenMapping[AnthropicModelName, ModelInfo] = Fro
                 cost_per_5m_cache_write_token=6.25 / 1_000_000,
                 cost_per_1h_cache_write_token=10 / 1_000_000,
                 cost_per_cache_read_token=0.50 / 1_000_000,
+            ),
+        ),
+        AnthropicModelName.CLAUDE_FABLE_5: ModelInfo(
+            model_name=AnthropicModelName.CLAUDE_FABLE_5,
+            cost_per_input_token=10.00 / 1_000_000,
+            cost_per_output_token=50.00 / 1_000_000,
+            max_input_tokens=200_000,
+            max_output_tokens=128_000,
+            rate_limit_req=4000 / 60,
+            rate_limit_tok=2_000_000 / 60,
+            rate_limit_output_tok=400_000 / 60,
+            provider_specific_info=AnthropicModelInfo(
+                cost_per_5m_cache_write_token=12.50 / 1_000_000,
+                cost_per_1h_cache_write_token=20 / 1_000_000,
+                cost_per_cache_read_token=1.00 / 1_000_000,
             ),
         ),
         AnthropicModelName.CLAUDE_4_SONNET: ModelInfo(
@@ -293,6 +309,20 @@ ANTHROPIC_MODEL_INFO_BY_NAME: FrozenMapping[AnthropicModelName, ModelInfo] = Fro
             rate_limit_tok=1_000_000 / 60,
             rate_limit_output_tok=200_000 / 60,
         ),
+        AnthropicModelName.CLAUDE_FABLE_5_LONG: ModelInfo(
+            model_name=AnthropicModelName.CLAUDE_FABLE_5_LONG,
+            # Fable 5 has a native 1M context window. Long-context pricing tiers mirror the Opus
+            # long-context multipliers: the first 200_000 input tokens use the 10.0 / 1_000_000 rate
+            # and the next up to 800_000 use 20.0 / 1_000_000, so the maximum average cost per input
+            # token is (10.0 * 200_000 + 20.0 * 800_000) / 1_000_000 = 18.0 per 1_000_000.
+            cost_per_input_token=18.00 / 1_000_000,
+            cost_per_output_token=75.00 / 1_000_000,
+            max_input_tokens=1_000_000,
+            max_output_tokens=128_000,
+            rate_limit_req=None,  # Currently no limit set in our dashboard
+            rate_limit_tok=1_000_000 / 60,
+            rate_limit_output_tok=200_000 / 60,
+        ),
     }
 )
 
@@ -305,8 +335,29 @@ _MODELS_WITHOUT_TEMPERATURE: frozenset[AnthropicModelName] = frozenset(
         AnthropicModelName.CLAUDE_4_7_OPUS_LONG,
         AnthropicModelName.CLAUDE_4_8_OPUS,
         AnthropicModelName.CLAUDE_4_8_OPUS_LONG,
+        AnthropicModelName.CLAUDE_FABLE_5,
+        AnthropicModelName.CLAUDE_FABLE_5_LONG,
     }
 )
+
+
+def _extract_text_from_content_blocks(content_blocks: list) -> str:
+    """Concatenate the text from all ``text`` content blocks in an Anthropic message.
+
+    Some models (e.g. Claude Fable 5) emit a ``thinking`` block before the final ``text`` block even
+    when extended thinking is not explicitly requested, so the response can contain more than one
+    content block. We ignore non-text blocks (``thinking``, ``redacted_thinking``, etc.) and return
+    only the visible text. For responses with a single ``text`` block this matches the previous
+    ``only(content).text`` behavior.
+    """
+    text_blocks = [block.text for block in content_blocks if getattr(block, "type", None) == "text"]
+    if not text_blocks:
+        raise BadAPIRequestError(
+            f"Anthropic response contained no text content blocks (block types: "
+            f"{[getattr(block, 'type', None) for block in content_blocks]})"
+        )
+    return "".join(text_blocks)
+
 
 _ROLE_TO_ANTHROPIC_ROLE: Final[FrozenMapping[str, str]] = FrozenDict(
     {
@@ -535,6 +586,7 @@ class AnthropicAPI(LanguageModelAPI):
                     AnthropicModelName.CLAUDE_4_6_OPUS_LONG: AnthropicModelName.CLAUDE_4_6_OPUS,
                     AnthropicModelName.CLAUDE_4_7_OPUS_LONG: AnthropicModelName.CLAUDE_4_7_OPUS,
                     AnthropicModelName.CLAUDE_4_8_OPUS_LONG: AnthropicModelName.CLAUDE_4_8_OPUS,
+                    AnthropicModelName.CLAUDE_FABLE_5_LONG: AnthropicModelName.CLAUDE_FABLE_5,
                 }
 
                 if self.model_name in _LONG_TO_STANDARD:
@@ -567,7 +619,7 @@ class AnthropicAPI(LanguageModelAPI):
                         written_5m=api_result.usage.cache_creation.ephemeral_5m_input_tokens,
                         written_1h=api_result.usage.cache_creation.ephemeral_1h_input_tokens,
                     )
-                text = only(api_result.content).text
+                text = _extract_text_from_content_blocks(api_result.content)
                 if api_result.stop_reason:
                     stop_reason = _ANTHROPIC_STOP_REASON_TO_STOP_REASON.get(
                         str(api_result.stop_reason), ResponseStopReason.NONE
@@ -617,6 +669,7 @@ class AnthropicAPI(LanguageModelAPI):
                     AnthropicModelName.CLAUDE_4_6_OPUS_LONG: AnthropicModelName.CLAUDE_4_6_OPUS,
                     AnthropicModelName.CLAUDE_4_7_OPUS_LONG: AnthropicModelName.CLAUDE_4_7_OPUS,
                     AnthropicModelName.CLAUDE_4_8_OPUS_LONG: AnthropicModelName.CLAUDE_4_8_OPUS,
+                    AnthropicModelName.CLAUDE_FABLE_5_LONG: AnthropicModelName.CLAUDE_FABLE_5,
                 }
 
                 if self.model_name in _LONG_TO_STANDARD_STREAM:
@@ -647,7 +700,7 @@ class AnthropicAPI(LanguageModelAPI):
                         yield LanguageModelStreamDeltaEvent(delta=text_delta)
 
                     final_message = await stream.get_final_message()
-                    text = only(final_message.content).text
+                    text = _extract_text_from_content_blocks(final_message.content)
                     stop_reason = (
                         final_message.stop_reason if final_message.stop_reason is not None else ResponseStopReason.NONE
                     )

--- a/vet/imbue_core/agents/llm_apis/anthropic_api_test.py
+++ b/vet/imbue_core/agents/llm_apis/anthropic_api_test.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+
+import pytest
+
+from vet.imbue_core.agents.llm_apis.anthropic_api import _extract_text_from_content_blocks
+from vet.imbue_core.agents.llm_apis.errors import BadAPIRequestError
+
+
+@dataclass
+class _Block:
+    type: str
+    text: str = ""
+
+
+def test_single_text_block_returns_text() -> None:
+    assert _extract_text_from_content_blocks([_Block(type="text", text="hello")]) == "hello"
+
+
+def test_thinking_block_is_ignored() -> None:
+    # Fable 5 emits a thinking block before the text block even without extended thinking enabled.
+    blocks = [_Block(type="thinking", text="(reasoning)"), _Block(type="text", text="answer")]
+    assert _extract_text_from_content_blocks(blocks) == "answer"
+
+
+def test_multiple_text_blocks_are_concatenated() -> None:
+    blocks = [_Block(type="text", text="foo"), _Block(type="text", text="bar")]
+    assert _extract_text_from_content_blocks(blocks) == "foobar"
+
+
+def test_refusal_with_empty_content_returns_empty_string() -> None:
+    # Fable 5's safety classifiers can return a refusal with no content blocks at all.
+    assert _extract_text_from_content_blocks([], stop_reason="refusal") == ""
+
+
+def test_empty_content_without_refusal_raises() -> None:
+    with pytest.raises(BadAPIRequestError):
+        _extract_text_from_content_blocks([], stop_reason="end_turn")
+
+
+def test_only_thinking_block_without_refusal_raises() -> None:
+    with pytest.raises(BadAPIRequestError):
+        _extract_text_from_content_blocks([_Block(type="thinking", text="(reasoning)")], stop_reason="end_turn")

--- a/vet/imbue_core/agents/llm_apis/anthropic_api_test.py
+++ b/vet/imbue_core/agents/llm_apis/anthropic_api_test.py
@@ -2,8 +2,11 @@ from dataclasses import dataclass
 
 import pytest
 
+from vet.imbue_core.agents.llm_apis.anthropic_api import AnthropicAPI
+from vet.imbue_core.agents.llm_apis.anthropic_api import AnthropicModelName
 from vet.imbue_core.agents.llm_apis.anthropic_api import _extract_text_from_content_blocks
 from vet.imbue_core.agents.llm_apis.errors import BadAPIRequestError
+from vet.imbue_core.agents.llm_apis.errors import ModelRefusalError
 
 
 @dataclass
@@ -27,9 +30,17 @@ def test_multiple_text_blocks_are_concatenated() -> None:
     assert _extract_text_from_content_blocks(blocks) == "foobar"
 
 
-def test_refusal_with_empty_content_returns_empty_string() -> None:
-    # Fable 5's safety classifiers can return a refusal with no content blocks at all.
-    assert _extract_text_from_content_blocks([], stop_reason="refusal") == ""
+def test_refusal_with_empty_content_raises_model_refusal_error() -> None:
+    # Fable 5's safety classifiers can return a refusal with no content blocks at all. This must
+    # surface as an error to the user rather than being treated as an empty (clean) response.
+    with pytest.raises(ModelRefusalError):
+        _extract_text_from_content_blocks([], stop_reason="refusal")
+
+
+def test_refusal_with_text_returns_text() -> None:
+    # If the refusal stop reason somehow accompanies generated text, keep the text.
+    blocks = [_Block(type="text", text="partial answer")]
+    assert _extract_text_from_content_blocks(blocks, stop_reason="refusal") == "partial answer"
 
 
 def test_empty_content_without_refusal_raises() -> None:
@@ -40,3 +51,16 @@ def test_empty_content_without_refusal_raises() -> None:
 def test_only_thinking_block_without_refusal_raises() -> None:
     with pytest.raises(BadAPIRequestError):
         _extract_text_from_content_blocks([_Block(type="thinking", text="(reasoning)")], stop_reason="end_turn")
+
+
+def test_default_timeout_per_model() -> None:
+    # Fable 5's always-on adaptive thinking makes review-sized responses routinely take minutes,
+    # so it gets a much longer default timeout than other models.
+    fable = AnthropicAPI(model_name=AnthropicModelName.CLAUDE_FABLE_5, cache_path=None)
+    assert fable._get_timeout() == 600.0
+
+    opus = AnthropicAPI(model_name=AnthropicModelName.CLAUDE_4_8_OPUS, cache_path=None)
+    assert opus._get_timeout() == 60.0
+
+    explicit = AnthropicAPI(model_name=AnthropicModelName.CLAUDE_FABLE_5, cache_path=None, timeout=30.0)
+    assert explicit._get_timeout() == 30.0

--- a/vet/imbue_core/agents/llm_apis/errors.py
+++ b/vet/imbue_core/agents/llm_apis/errors.py
@@ -77,6 +77,17 @@ class MissingAPIKeyError(LanguageModelError):
     pass
 
 
+class ModelRefusalError(LanguageModelError):
+    """Exception raised when the model refuses to generate any response.
+
+    Some models (e.g. Claude Fable 5) have safety classifiers that can decline a request,
+    returning a successful API response with a refusal stop reason and no content. We surface
+    this to the user instead of silently treating the empty response as a clean result. These
+    are deliberately not cached (the same prompt may succeed later) and not retried (the
+    classifiers are unlikely to change their decision on an immediate identical retry).
+    """
+
+
 class RetriableLanguageModelError(LanguageModelError):
     pass
 

--- a/vet/imbue_core/agents/llm_apis/openai_compatible_api.py
+++ b/vet/imbue_core/agents/llm_apis/openai_compatible_api.py
@@ -24,6 +24,7 @@ from vet.imbue_core.agents.llm_apis.data_types import LanguageModelResponse
 from vet.imbue_core.agents.llm_apis.data_types import LanguageModelResponseUsage
 from vet.imbue_core.agents.llm_apis.data_types import ResponseStopReason
 from vet.imbue_core.agents.llm_apis.errors import BadAPIRequestError
+from vet.imbue_core.agents.llm_apis.errors import ModelRefusalError
 from vet.imbue_core.agents.llm_apis.errors import PromptTooLongError
 from vet.imbue_core.agents.llm_apis.errors import TransientLanguageModelError
 from vet.imbue_core.agents.llm_apis.language_model_api import LanguageModelAPI
@@ -212,6 +213,7 @@ class OpenAICompatibleAPI(LanguageModelAPI):
 
             usage = None
             finish_reason: str | None = None
+            has_streamed_text = False
             async for chunk in api_result:
                 if hasattr(chunk, "usage") and chunk.usage is not None:
                     usage = chunk.usage
@@ -222,11 +224,19 @@ class OpenAICompatibleAPI(LanguageModelAPI):
                     data = only(chunk.choices)
                     delta = data.delta.content
                     if delta is not None:
+                        if delta:
+                            has_streamed_text = True
                         yield LanguageModelStreamDeltaEvent(delta=delta)
                     if data.finish_reason:
                         finish_reason = str(data.finish_reason)
 
             stop_reason = _OPENAI_COMPATIBLE_STOP_REASON_TO_STOP_REASON.get(str(finish_reason), ResponseStopReason.NONE)
+            # See _parse_response: a content filter refusal with no generated text is surfaced as an
+            # error rather than silently yielding an empty response.
+            if stop_reason == ResponseStopReason.CONTENT_FILTER and not has_streamed_text:
+                raise ModelRefusalError(
+                    "The model refused to generate a response (the provider's content filter " "declined the request)."
+                )
             if params.stop is not None and stop_reason == ResponseStopReason.END_TURN:
                 yield LanguageModelStreamDeltaEvent(delta=params.stop)
 
@@ -270,12 +280,20 @@ class OpenAICompatibleAPI(LanguageModelAPI):
     ) -> tuple[LanguageModelResponse, ...]:
         results = []
         for data in response.choices:
-            assert data.message.content is not None
-            text = data.message.content
-            token_count = self.count_tokens(text) + prompt_tokens
             stop_reason = _OPENAI_COMPATIBLE_STOP_REASON_TO_STOP_REASON.get(
                 str(data.finish_reason), ResponseStopReason.NONE
             )
+            # Models with safety classifiers (e.g. Claude Fable 5 via Anthropic's OpenAI-compatible
+            # endpoint) can refuse a request, returning finish_reason "content_filter" with empty
+            # content. Surface that to the user instead of returning an empty response. If the
+            # filter triggered after some text was generated, we keep the partial text.
+            if stop_reason == ResponseStopReason.CONTENT_FILTER and not data.message.content:
+                raise ModelRefusalError(
+                    "The model refused to generate a response (the provider's content filter " "declined the request)."
+                )
+            assert data.message.content is not None
+            text = data.message.content
+            token_count = self.count_tokens(text) + prompt_tokens
             if stop is not None and stop_reason == ResponseStopReason.END_TURN:
                 text += stop
             result = LanguageModelResponse(

--- a/vet/imbue_core/agents/llm_apis/openai_compatible_api_test.py
+++ b/vet/imbue_core/agents/llm_apis/openai_compatible_api_test.py
@@ -1,0 +1,70 @@
+import pytest
+from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_message import ChatCompletionMessage
+
+from vet.imbue_core.agents.llm_apis.data_types import ResponseStopReason
+from vet.imbue_core.agents.llm_apis.errors import ModelRefusalError
+from vet.imbue_core.agents.llm_apis.openai_compatible_api import OpenAICompatibleAPI
+
+
+def _make_api() -> OpenAICompatibleAPI:
+    return OpenAICompatibleAPI(
+        model_name="test-model",
+        context_window=100000,
+        max_output_tokens=1000,
+        cache_path=None,
+    )
+
+
+def _make_completion(content: str | None, finish_reason: str) -> ChatCompletion:
+    return ChatCompletion(
+        id="chatcmpl-test",
+        choices=[
+            Choice(
+                index=0,
+                finish_reason=finish_reason,  # type: ignore[arg-type]
+                message=ChatCompletionMessage(role="assistant", content=content),
+            )
+        ],
+        created=0,
+        model="test-model",
+        object="chat.completion",
+    )
+
+
+def test_parse_response_returns_text() -> None:
+    api = _make_api()
+    results = api._parse_response(
+        _make_completion("hello", "stop"), prompt_tokens=10, stop=None, network_failure_count=0
+    )
+    assert results[0].text == "hello"
+    assert results[0].stop_reason == ResponseStopReason.END_TURN
+
+
+def test_parse_response_content_filter_with_empty_content_raises() -> None:
+    # Anthropic's OpenAI-compatible endpoint returns finish_reason "content_filter" with empty
+    # content when a model with safety classifiers (e.g. Claude Fable 5) refuses a request.
+    api = _make_api()
+    with pytest.raises(ModelRefusalError):
+        api._parse_response(
+            _make_completion("", "content_filter"), prompt_tokens=10, stop=None, network_failure_count=0
+        )
+
+
+def test_parse_response_content_filter_with_none_content_raises() -> None:
+    api = _make_api()
+    with pytest.raises(ModelRefusalError):
+        api._parse_response(
+            _make_completion(None, "content_filter"), prompt_tokens=10, stop=None, network_failure_count=0
+        )
+
+
+def test_parse_response_content_filter_with_partial_text_keeps_text() -> None:
+    # If the filter triggered after some text was generated, the partial text is kept.
+    api = _make_api()
+    results = api._parse_response(
+        _make_completion("partial", "content_filter"), prompt_tokens=10, stop=None, network_failure_count=0
+    )
+    assert results[0].text == "partial"
+    assert results[0].stop_reason == ResponseStopReason.CONTENT_FILTER


### PR DESCRIPTION
Adds the claude-fable-5 model to the Anthropic provider, registers fable in both the project-local config (.vet/models.json) and the remote model registry (registry/models.json) via the openai-compatible endpoint, and fixes text extraction to handle the thinking content block that fable-5 returns by default.

Fable 5 emits a thinking block before its text block even without extended thinking enabled, so the previous only(content).text call (which assumes a single block) raised an error. Text is now concatenated from all text blocks, which is backward-compatible with single-block responses from existing models.

Fable 5 has a native 1M-token context window, verified against the API and the Models API metadata (max_input_tokens 1000000, max_tokens 128000): a 960k-token request succeeds with no beta header and requests over 1,000,000 tokens are rejected. Pricing is a flat 10/50 per MTok with no long-context tier, so there is no -long variant.

Model refusals are surfaced to the user instead of silently producing an empty result. Fable 5's safety classifiers can return stop_reason refusal with no content blocks (native API) or finish_reason content_filter with empty content (OpenAI-compatible endpoint); both now raise ModelRefusalError, which the CLI reports with an actionable message and a nonzero exit code. Refusals are not cached and not retried. Partial text generated before a content filter triggered is kept.

claude-fable-5 also gets a longer per-model API client timeout (600s instead of 60s): its always-on adaptive thinking counts toward output and review-sized prompts measure 190-210s to complete, so the previous 60s timeout aborted requests that would have succeeded.

Default model is unchanged (still claude-opus-4-8).

Verified end to end against the Anthropic API: the native claude-fable-5 model, the project-local openai-compatible fable model, the remote-registry openai-compatible fable model (via VET_REGISTRY_URL into the registry cache), and the released vet 0.2.14 from PyPI resolving fable purely through the registry. Live refusals on both API paths raise ModelRefusalError and the CLI surfaces them. All unit tests pass and the diff is clean across many vet runs (LLM API with fable-5 native, fable-5 compat, and opus-4-8, plus Claude Code and OpenCode agentic runs).