### PR TITLE
Annotate --list-configs output with model ID validation warnings

### DIFF
--- a/vet/cli/main.py
+++ b/vet/cli/main.py
@@ -17,6 +17,7 @@ from vet.cli.config.cli_config_schema import CliConfigPreset
 from vet.cli.config.loader import ConfigLoadError
 from vet.cli.config.loader import get_cli_config_file_paths
 from vet.cli.config.loader import get_config_preset
+from vet.cli.config.loader import get_model_ids_from_config
 from vet.cli.config.loader import load_cli_config
 from vet.cli.config.loader import load_custom_guides_config
 from vet.cli.config.loader import load_models_config
@@ -327,7 +328,12 @@ def list_fields() -> None:
         print(f"  {field}")
 
 
-def list_configs(cli_configs: dict[str, CliConfigPreset], repo_path: Path) -> None:
+def list_configs(
+    cli_configs: dict[str, CliConfigPreset],
+    repo_path: Path,
+    user_config: ModelsConfig | None = None,
+    registry_config: ModelsConfig | None = None,
+) -> None:
     print("Available configurations:")
     print()
 
@@ -345,7 +351,16 @@ def list_configs(cli_configs: dict[str, CliConfigPreset], repo_path: Path) -> No
         preset_dict = preset.model_dump(exclude_none=True)
         if preset_dict:
             for key, value in preset_dict.items():
-                print(f"    {key}: {value}")
+                if key == "model" and user_config is not None:
+                    in_user = value in get_model_ids_from_config(user_config)
+                    in_registry = registry_config is not None and value in get_model_ids_from_config(registry_config)
+                    if not in_user and not in_registry:
+                        suffix = "  ← not in models.json or registry; if this is a built-in model name this is fine, otherwise check for a typo"
+                    else:
+                        suffix = ""
+                    print(f"    {key}: {value}{suffix}")
+                else:
+                    print(f"    {key}: {value}")
         else:
             print("    (uses all defaults)")
         print()
@@ -523,7 +538,7 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     if args.list_configs:
-        list_configs(cli_configs, repo_path)
+        list_configs(cli_configs, repo_path, user_config, registry_config)
         return 0
 
     if args.config is not None:

--- a/vet/cli/main_test.py
+++ b/vet/cli/main_test.py
@@ -147,6 +147,100 @@ class TestListModels:
         assert "remote-model-b" in captured.out
 
 
+class TestListConfigs:
+    """CLI integration tests for the --list-configs flag."""
+
+    def _write_models_json(self, tmp_path: Path, model_id: str) -> None:
+        config_dir = tmp_path / "config" / "vet"
+        config_dir.mkdir(parents=True)
+        (config_dir / "models.json").write_text(
+            json.dumps(
+                {
+                    "providers": {
+                        "local": {
+                            "base_url": "http://localhost:11434/v1",
+                            "models": {
+                                model_id: {
+                                    "context_window": 131072,
+                                    "max_output_tokens": 8192,
+                                    "supports_temperature": True,
+                                }
+                            },
+                        }
+                    }
+                }
+            )
+        )
+
+    def _write_configs_toml(self, tmp_path: Path, model_id: str) -> None:
+        config_dir = tmp_path / "config" / "vet"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "configs.toml").write_text(f'[mypreset]\nmodel = "{model_id}"\n')
+
+    def test_list_configs_valid_model_no_warning(self, tmp_path: Path, capsys) -> None:
+        self._write_models_json(tmp_path, "my-local-model")
+        self._write_configs_toml(tmp_path, "my-local-model")
+        env = _env_for_isolated_config(tmp_path)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        with patch.dict(os.environ, env):
+            exit_code = main(["--list-configs", "--repo", str(repo)])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "my-local-model" in captured.out
+        assert "check for a typo" not in captured.out
+
+    def test_list_configs_unknown_model_shows_warning(self, tmp_path: Path, capsys) -> None:
+        self._write_models_json(tmp_path, "my-local-model")
+        self._write_configs_toml(tmp_path, "my-local-model-typo")
+        env = _env_for_isolated_config(tmp_path)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        with patch.dict(os.environ, env):
+            exit_code = main(["--list-configs", "--repo", str(repo)])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "my-local-model-typo" in captured.out
+        assert "check for a typo" in captured.out
+
+    def test_list_configs_registry_model_no_warning(self, tmp_path: Path, capsys, make_mock_response) -> None:
+        registry_json = json.dumps(
+            {
+                "providers": {
+                    "remote": {
+                        "base_url": "http://remote:8080/v1",
+                        "models": {
+                            "registry-only-model": {
+                                "context_window": 128000,
+                                "max_output_tokens": 16384,
+                                "supports_temperature": True,
+                            }
+                        },
+                    }
+                }
+            }
+        )
+        mock_response = make_mock_response(registry_json.encode())
+        self._write_configs_toml(tmp_path, "registry-only-model")
+        env = _env_for_isolated_config(tmp_path)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        with patch.dict(os.environ, env):
+            with patch("vet.cli.config.loader.urllib.request.urlopen", return_value=mock_response):
+                main(["--update-models"])
+            exit_code = main(["--list-configs", "--repo", str(repo)])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "registry-only-model" in captured.out
+        assert "check for a typo" not in captured.out
+
+
 class TestModelRefusal:
     """CLI integration tests for surfacing model refusals."""
 


### PR DESCRIPTION
## Summary

- `vet --list-configs` now annotates any preset's `model` field with a warning when the model ID is not found in `models.json` or the remote registry
- Makes the `configs.toml` → `models.json` link explicit and inspectable without needing a full vet run to discover misconfiguration
- Validation uses only the already-loaded config objects (no LLM SDK imports), keeping `--list-configs` within the 0.4s startup time budget
- Built-in model names (e.g. `claude-opus-4-8`) are not checked to avoid the ~1s SDK import chain; the warning message notes they are still valid

Closes #209

## Example output

Before (no feedback on model validity):
```
Available configurations:

  ci:
    model: my-local-qwen-typo
    confidence_threshold: 0.9
```

After:
```
Available configurations:

  ci:
    model: my-local-qwen-typo  ← not in models.json or registry; if this is a built-in model name this is fine, otherwise check for a typo
    confidence_threshold: 0.9
```

## Test plan

- [ ] `test_list_configs_valid_model_no_warning` — model in models.json, no warning shown
- [ ] `test_list_configs_unknown_model_shows_warning` — typo in model ID, warning shown
- [ ] `test_list_configs_registry_model_no_warning` — model in remote registry cache, no warning
- [ ] `test_cli_startup_time[--list-configs]` — startup time stays under 0.4s

🤖 Generated with [Claude Code](https://claude.com/claude-code)