### PR TITLE
Add cost tracking to vet output

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ Vet snapshots the repo and diff, optionally adds a goal and agent conversation, 
 - Exit code `2`: invalid usage/configuration error
 - Exit code `10`: issues found
 
+After each run, vet prints a cost/token summary to stderr (unless `--quiet`), for example:
+
+```text
+Cost: $0.042 · 12,400 in / 1,820 out tokens · 2 LLM calls
+```
+
+With `--output-format json`, the same totals are included under a top-level `"usage"` object. Models or harnesses that do not report pricing show `Cost: unknown` (and `"cost_usd": null` in JSON). Per-call detail remains available via `-vv` TRACE logs.
+
 Output formats:
 - `text`
 - `json`

--- a/vet/api.py
+++ b/vet/api.py
@@ -10,6 +10,8 @@ from loguru import logger
 
 from vet.imbue_core.data_types import IdentifiedVerifyIssue
 from vet.imbue_core.data_types import IssueIdentificationDebugInfo
+from vet.imbue_core.data_types import RunUsage
+from vet.imbue_core.data_types import aggregate_run_usage
 from vet.imbue_tools.get_conversation_history.get_conversation_history import ConversationLoadingError
 from vet.imbue_tools.get_conversation_history.input_data_types import IdentifierInputs
 from vet.imbue_tools.repo_utils.project_context import LazyProjectContext
@@ -104,7 +106,7 @@ def find_issues(
     conversation_history: tuple[ConversationMessageUnion, ...] | None = None,
     extra_context: str | None = None,
     only_staged: bool = False,
-) -> tuple[IdentifiedVerifyIssue, ...]:
+) -> tuple[tuple[IdentifiedVerifyIssue, ...], RunUsage]:
     if only_staged:
         logger.debug(
             "Finding issues in {repo_path} (staged changes)",
@@ -131,9 +133,9 @@ def find_issues(
                 relative_to=relative_to,
             )
         # No code changes detected, so no issues to find.
-        return tuple()
+        return tuple(), RunUsage()
 
-    issues, _, _ = get_issues_with_raw_responses(
+    issues, debug_info, _ = get_issues_with_raw_responses(
         base_commit=base_commit,
         diff=diff,
         diff_no_binary=diff_no_binary,
@@ -143,4 +145,4 @@ def find_issues(
         conversation_history=conversation_history,
         extra_context=extra_context,
     )
-    return issues
+    return issues, aggregate_run_usage(debug_info)

--- a/vet/cli/main.py
+++ b/vet/cli/main.py
@@ -598,7 +598,9 @@ def main(argv: list[str] | None = None) -> int:
     from vet.cli.models import validate_model_id
     from vet.formatters import format_github_review
     from vet.formatters import format_issue_text
+    from vet.formatters import format_run_usage
     from vet.formatters import issue_to_dict
+    from vet.formatters import usage_to_dict
     from vet.imbue_core.agents.llm_apis.errors import BadAPIRequestError
     from vet.imbue_core.agents.llm_apis.errors import MissingAPIKeyError
     from vet.imbue_core.agents.llm_apis.errors import ModelRefusalError
@@ -704,7 +706,7 @@ def main(argv: list[str] | None = None) -> int:
             )
 
     try:
-        issues = find_issues(
+        issues, usage = find_issues(
             repo_path=repo_path,
             relative_to=args.base_commit,
             goal=goal,
@@ -765,19 +767,25 @@ def main(argv: list[str] | None = None) -> int:
         output_stream = sys.stdout
 
     try:
+        exit_code = 10 if issues else 0
+
         if not issues:
             if args.output_format == "json":
-                print(json.dumps({"issues": []}, indent=2), file=output_stream)
+                print(
+                    json.dumps({"issues": [], "usage": usage_to_dict(usage)}, indent=2),
+                    file=output_stream,
+                )
             elif args.output_format == "github":
                 payload = format_github_review(issues, output_fields)
                 print(json.dumps(payload, indent=2), file=output_stream)
             elif not args.quiet:
                 print("No issues found.", file=output_stream)
-            return 0
-
-        if args.output_format == "json":
+        elif args.output_format == "json":
             issues_list = [issue_to_dict(issue, output_fields) for issue in issues]
-            print(json.dumps({"issues": issues_list}, indent=2), file=output_stream)
+            print(
+                json.dumps({"issues": issues_list, "usage": usage_to_dict(usage)}, indent=2),
+                file=output_stream,
+            )
         elif args.output_format == "github":
             payload = format_github_review(issues, output_fields)
             print(json.dumps(payload, indent=2), file=output_stream)
@@ -786,7 +794,12 @@ def main(argv: list[str] | None = None) -> int:
                 print(format_issue_text(issue, output_fields), file=output_stream)
                 print(file=output_stream)
 
-        return 10
+        if not args.quiet:
+            usage_summary = format_run_usage(usage)
+            if usage_summary is not None:
+                print(usage_summary, file=sys.stderr)
+
+        return exit_code
     finally:
         if output_file is not None:
             output_file.close()

--- a/vet/cli/main_test.py
+++ b/vet/cli/main_test.py
@@ -180,3 +180,95 @@ class TestModelRefusal:
         captured = capsys.readouterr()
         assert "refused" in captured.err
         assert "try re-running" in captured.err
+
+
+def _git_repo_with_change(tmp_path: Path) -> Path:
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "init"],
+        cwd=repo,
+        check=True,
+    )
+    (repo / "file.py").write_text("x = 1\n")
+    subprocess.run(["git", "add", "file.py"], cwd=repo, check=True)
+    return repo
+
+
+class TestRunUsageOutput:
+    """CLI tests for run-level cost/token reporting."""
+
+    def test_text_stderr_includes_cost_summary(self, tmp_path: Path, capsys) -> None:
+        from vet.imbue_core.data_types import RunUsage
+
+        repo = _git_repo_with_change(tmp_path)
+        env = _env_for_isolated_config(tmp_path) | {"ANTHROPIC_API_KEY": "test-key"}
+        usage = RunUsage(input_tokens=12400, output_tokens=1820, cost_usd=0.042, llm_calls=2)
+
+        with patch.dict(os.environ, env):
+            with patch("vet.cli.main.configure_logging"):
+                with patch("vet.api.find_issues", return_value=(tuple(), usage)):
+                    exit_code = main(["test goal", "--repo", str(repo)])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "No issues found." in captured.out
+        assert "Cost: $0.042 · 12,400 in / 1,820 out tokens · 2 LLM calls" in captured.err
+
+    def test_json_includes_usage_object(self, tmp_path: Path, capsys) -> None:
+        from vet.imbue_core.data_types import RunUsage
+
+        repo = _git_repo_with_change(tmp_path)
+        env = _env_for_isolated_config(tmp_path) | {"ANTHROPIC_API_KEY": "test-key"}
+        usage = RunUsage(input_tokens=100, output_tokens=20, cost_usd=0.01, llm_calls=1)
+
+        with patch.dict(os.environ, env):
+            with patch("vet.cli.main.configure_logging"):
+                with patch("vet.api.find_issues", return_value=(tuple(), usage)):
+                    exit_code = main(["test goal", "--repo", str(repo), "--output-format", "json", "--quiet"])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert payload["issues"] == []
+        assert payload["usage"]["input_tokens"] == 100
+        assert payload["usage"]["output_tokens"] == 20
+        assert payload["usage"]["cost_usd"] == 0.01
+        assert payload["usage"]["llm_calls"] == 1
+        assert "Cost:" not in captured.err
+
+    def test_quiet_hides_human_cost_summary(self, tmp_path: Path, capsys) -> None:
+        from vet.imbue_core.data_types import RunUsage
+
+        repo = _git_repo_with_change(tmp_path)
+        env = _env_for_isolated_config(tmp_path) | {"ANTHROPIC_API_KEY": "test-key"}
+        usage = RunUsage(input_tokens=50, output_tokens=5, cost_usd=0.001, llm_calls=1)
+
+        with patch.dict(os.environ, env):
+            with patch("vet.cli.main.configure_logging"):
+                with patch("vet.api.find_issues", return_value=(tuple(), usage)):
+                    exit_code = main(["test goal", "--repo", str(repo), "--quiet"])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "Cost:" not in captured.err
+
+    def test_unknown_cost_printed_when_cost_missing(self, tmp_path: Path, capsys) -> None:
+        from vet.imbue_core.data_types import RunUsage
+
+        repo = _git_repo_with_change(tmp_path)
+        env = _env_for_isolated_config(tmp_path) | {"ANTHROPIC_API_KEY": "test-key"}
+        usage = RunUsage(input_tokens=50, output_tokens=5, cost_usd=None, llm_calls=1)
+
+        with patch.dict(os.environ, env):
+            with patch("vet.cli.main.configure_logging"):
+                with patch("vet.api.find_issues", return_value=(tuple(), usage)):
+                    exit_code = main(["test goal", "--repo", str(repo)])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "Cost: unknown · 50 in / 5 out tokens · 1 LLM call" in captured.err

--- a/vet/formatters.py
+++ b/vet/formatters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pydantic import BaseModel
 
 from vet.imbue_core.data_types import IdentifiedVerifyIssue
+from vet.imbue_core.data_types import RunUsage
 
 OUTPUT_FORMATS = ["text", "json", "github"]
 
@@ -14,6 +15,37 @@ OUTPUT_FIELDS = [
     "description",
     "severity",
 ]
+
+
+def usage_to_dict(usage: RunUsage) -> dict:
+    return usage.model_dump(mode="json")
+
+
+def _format_usd(amount: float) -> str:
+    formatted = f"{amount:.4f}".rstrip("0").rstrip(".")
+    if "." not in formatted:
+        return f"${formatted}.00"
+    dollars, cents = formatted.split(".", 1)
+    if len(cents) == 1:
+        formatted = f"{dollars}.{cents}0"
+    return f"${formatted}"
+
+
+def format_run_usage(usage: RunUsage) -> str | None:
+    """Format a one-line run usage summary for stderr. Returns None when there were no LLM calls."""
+    if usage.llm_calls == 0:
+        return None
+
+    if usage.cost_usd is None:
+        cost_part = "Cost: unknown"
+    else:
+        cost_part = f"Cost: {_format_usd(usage.cost_usd)}"
+
+    call_noun = "call" if usage.llm_calls == 1 else "calls"
+    return (
+        f"{cost_part} · {usage.input_tokens:,} in / {usage.output_tokens:,} out tokens"
+        f" · {usage.llm_calls} LLM {call_noun}"
+    )
 
 
 class IssueOutput(BaseModel):

--- a/vet/formatters_usage_test.py
+++ b/vet/formatters_usage_test.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from vet.formatters import format_run_usage
+from vet.formatters import usage_to_dict
+from vet.imbue_core.data_types import InvocationInfo
+from vet.imbue_core.data_types import IssueIdentificationDebugInfo
+from vet.imbue_core.data_types import IssueIdentificationLLMResponseMetadata
+from vet.imbue_core.data_types import LLMResponse
+from vet.imbue_core.data_types import RunUsage
+from vet.imbue_core.data_types import aggregate_run_usage
+
+
+def _llm_response(invocation_info: InvocationInfo | None) -> LLMResponse:
+    return LLMResponse(
+        metadata=IssueIdentificationLLMResponseMetadata(),
+        raw_response=("ok",),
+        invocation_info=invocation_info,
+    )
+
+
+def test_aggregate_run_usage_sums_tokens_and_cost() -> None:
+    debug_info = IssueIdentificationDebugInfo(
+        llm_responses=(
+            _llm_response(
+                InvocationInfo(
+                    input_tokens=1000,
+                    output_tokens=200,
+                    cache_creation_input_tokens=50,
+                    cache_read_input_tokens=100,
+                    cost=0.01,
+                    duration_ms=100.0,
+                )
+            ),
+            _llm_response(
+                InvocationInfo(
+                    input_tokens=500,
+                    output_tokens=50,
+                    cost=0.032,
+                    duration_ms=50.5,
+                )
+            ),
+        )
+    )
+
+    usage = aggregate_run_usage(debug_info)
+
+    assert usage == RunUsage(
+        input_tokens=1500,
+        output_tokens=250,
+        cache_creation_input_tokens=50,
+        cache_read_input_tokens=100,
+        cost_usd=0.042,
+        llm_calls=2,
+        duration_ms=150.5,
+    )
+
+
+def test_aggregate_run_usage_prefers_total_input_tokens() -> None:
+    debug_info = IssueIdentificationDebugInfo(
+        llm_responses=(
+            _llm_response(
+                InvocationInfo(
+                    input_tokens=100,
+                    total_input_tokens=250,
+                    output_tokens=10,
+                    cost=0.0,
+                )
+            ),
+        )
+    )
+
+    usage = aggregate_run_usage(debug_info)
+
+    assert usage.input_tokens == 250
+    assert usage.cost_usd == 0.0
+    assert usage.llm_calls == 1
+
+
+def test_aggregate_run_usage_unknown_cost_when_all_missing() -> None:
+    debug_info = IssueIdentificationDebugInfo(
+        llm_responses=(
+            _llm_response(InvocationInfo(input_tokens=10, output_tokens=5)),
+            _llm_response(InvocationInfo(input_tokens=20, output_tokens=8)),
+        )
+    )
+
+    usage = aggregate_run_usage(debug_info)
+
+    assert usage.input_tokens == 30
+    assert usage.output_tokens == 13
+    assert usage.cost_usd is None
+    assert usage.llm_calls == 2
+
+
+def test_aggregate_run_usage_counts_calls_without_invocation_info() -> None:
+    debug_info = IssueIdentificationDebugInfo(llm_responses=(_llm_response(None),))
+
+    usage = aggregate_run_usage(debug_info)
+
+    assert usage.llm_calls == 1
+    assert usage.input_tokens == 0
+    assert usage.cost_usd is None
+
+
+def test_format_run_usage_with_cost() -> None:
+    summary = format_run_usage(RunUsage(input_tokens=12400, output_tokens=1820, cost_usd=0.042, llm_calls=2))
+    assert summary == "Cost: $0.042 · 12,400 in / 1,820 out tokens · 2 LLM calls"
+
+
+def test_format_run_usage_unknown_cost() -> None:
+    summary = format_run_usage(RunUsage(input_tokens=100, output_tokens=20, llm_calls=1))
+    assert summary == "Cost: unknown · 100 in / 20 out tokens · 1 LLM call"
+
+
+def test_format_run_usage_omits_when_no_calls() -> None:
+    assert format_run_usage(RunUsage()) is None
+
+
+def test_usage_to_dict_includes_null_cost() -> None:
+    payload = usage_to_dict(RunUsage(input_tokens=10, output_tokens=2, llm_calls=1))
+    assert payload["cost_usd"] is None
+    assert payload["input_tokens"] == 10
+    assert payload["llm_calls"] == 1

--- a/vet/imbue_core/data_types.py
+++ b/vet/imbue_core/data_types.py
@@ -322,6 +322,19 @@ class InvocationInfo(SerializableModel):
     num_turns: int | None = None
 
 
+class RunUsage(SerializableModel):
+    """Aggregated token usage and cost for a full vet run."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    # None means cost was not reported by the provider/harness (distinct from $0.00).
+    cost_usd: float | None = None
+    llm_calls: int = 0
+    duration_ms: float | None = None
+
+
 class IssueIdentificationLLMResponseMetadata(SerializableModel):
     """Configuration metadata for LLM responses."""
 
@@ -345,6 +358,43 @@ class LLMResponse(SerializableModel):
 
 class IssueIdentificationDebugInfo(SerializableModel):
     llm_responses: tuple[LLMResponse, ...]
+
+
+def _sum_optional_ints(values: list[int | None]) -> int:
+    return sum(value for value in values if value is not None)
+
+
+def _input_tokens_for_invocation(info: InvocationInfo) -> int | None:
+    if info.total_input_tokens is not None:
+        return info.total_input_tokens
+    return info.input_tokens
+
+
+def aggregate_run_usage(debug_info: IssueIdentificationDebugInfo) -> RunUsage:
+    """Aggregate per-call invocation info into run-level usage totals."""
+    responses = debug_info.llm_responses
+    infos = [response.invocation_info for response in responses if response.invocation_info is not None]
+
+    input_tokens = _sum_optional_ints([_input_tokens_for_invocation(info) for info in infos])
+    output_tokens = _sum_optional_ints([info.output_tokens for info in infos])
+    cache_creation_input_tokens = _sum_optional_ints([info.cache_creation_input_tokens for info in infos])
+    cache_read_input_tokens = _sum_optional_ints([info.cache_read_input_tokens for info in infos])
+
+    known_costs = [info.cost for info in infos if info.cost is not None]
+    cost_usd = sum(known_costs) if known_costs else None
+
+    duration_values = [info.duration_ms for info in infos if info.duration_ms is not None]
+    duration_ms = sum(duration_values) if duration_values else None
+
+    return RunUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_creation_input_tokens=cache_creation_input_tokens,
+        cache_read_input_tokens=cache_read_input_tokens,
+        cost_usd=cost_usd,
+        llm_calls=len(responses),
+        duration_ms=duration_ms,
+    )
 
 
 class IssueIdentifierResult(SerializableModel):


### PR DESCRIPTION
## Summary
- Report aggregated run cost and token usage after each vet run (stderr summary unless `--quiet`)
- Include a top-level `usage` object in `--output-format json` for automation and cost comparisons
- Aggregate existing per-call `InvocationInfo` data instead of requiring `-vv` TRACE logs

Fixes #186

## Details
- Adds `RunUsage` + `aggregate_run_usage()` and plumbs it through `find_issues()`
- Unknown harness/provider pricing shows as `Cost: unknown` / `"cost_usd": null`
- GitHub review payloads stay issue-focused; cost summary still goes to stderr
- Documents the new output behavior in the README

**Note:** `find_issues()` now returns `(issues, RunUsage)` instead of only `issues`.

## Test plan
- [x] `uv run pytest vet/formatters_usage_test.py vet/cli/main_test.py::TestRunUsageOutput vet/formatters_test.py`
- [ ] Run `vet "goal"` and confirm stderr includes a `Cost: ...` summary line
- [ ] Run `vet "goal" --output-format json` and confirm top-level `"usage"` is present
- [ ] Run `vet "goal" --quiet` and confirm the human cost summary is suppressed
- [ ] Confirm agentic/harness runs with missing cost still report tokens and `Cost: unknown`